### PR TITLE
Add Amazon daily sales helper and dashboard visualization

### DIFF
--- a/scm_dashboard_v4/sales.py
+++ b/scm_dashboard_v4/sales.py
@@ -1,0 +1,106 @@
+"""Sales analytics helpers for the SCM dashboard."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence
+
+import pandas as pd
+
+
+@dataclass
+class SalesSeries:
+    """Simple container for prepared Amazon sales data."""
+
+    frame: pd.DataFrame
+
+    @property
+    def empty(self) -> bool:
+        return self.frame.empty
+
+
+def _normalize_list(values: Optional[Iterable[str]]) -> list[str]:
+    if not values:
+        return []
+    return [str(v).strip() for v in values if str(v).strip()]
+
+
+def prepare_amazon_daily_sales(
+    snapshots: Optional[pd.DataFrame],
+    *,
+    center_keyword: str = "amazon",
+    centers: Optional[Sequence[str]] = None,
+    skus: Optional[Sequence[str]] = None,
+    rolling_window: int = 7,
+) -> SalesSeries:
+    """Return daily Amazon inventory & sales derived from snapshot data."""
+
+    empty_result = SalesSeries(
+        pd.DataFrame(
+            {
+                "date": pd.Series(dtype="datetime64[ns]"),
+                "inventory_qty": pd.Series(dtype="float"),
+                "daily_sales": pd.Series(dtype="float"),
+            }
+        )
+    )
+
+    if snapshots is None or snapshots.empty:
+        return empty_result
+
+    df = snapshots.copy()
+
+    if "date" not in df.columns or "center" not in df.columns or "stock_qty" not in df.columns:
+        return empty_result
+
+    df["date"] = pd.to_datetime(df["date"], errors="coerce").dt.normalize()
+    df = df.dropna(subset=["date"])
+    if df.empty:
+        return empty_result
+
+    df["center"] = df["center"].astype(str)
+    if "resource_code" in df.columns:
+        df["resource_code"] = df["resource_code"].astype(str)
+    else:
+        df["resource_code"] = ""
+
+    selected_centers = _normalize_list(centers)
+    if selected_centers:
+        center_mask = df["center"].isin(selected_centers)
+    else:
+        center_mask = df["center"].str.contains(center_keyword, case=False, na=False)
+
+    df = df[center_mask]
+    if df.empty:
+        return empty_result
+
+    selected_skus = _normalize_list(skus)
+    if selected_skus:
+        df = df[df["resource_code"].isin(selected_skus)]
+        if df.empty:
+            return empty_result
+
+    grouped = df.groupby("date", as_index=True)["stock_qty"].sum().sort_index()
+    if grouped.empty:
+        return empty_result
+
+    full_range = pd.date_range(grouped.index.min(), grouped.index.max(), freq="D")
+    inventory = grouped.reindex(full_range).ffill()
+
+    sales = (-inventory.diff()).clip(lower=0)
+    sales = sales.fillna(0)
+
+    result = pd.DataFrame(
+        {
+            "date": inventory.index,
+            "inventory_qty": inventory.values,
+            "daily_sales": sales.values,
+        }
+    )
+
+    if rolling_window and rolling_window > 1:
+        result[f"sales_ma_{rolling_window}"] = (
+            result["daily_sales"].rolling(rolling_window, min_periods=1).mean()
+        )
+
+    return SalesSeries(result)

--- a/streamlit_scm_step_v4_modular.py
+++ b/streamlit_scm_step_v4_modular.py
@@ -6,6 +6,8 @@ from typing import Dict, List, Optional
 
 import pandas as pd
 import plotly.express as px
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
 import streamlit as st
 
 from scm_dashboard_v4.config import CENTER_COL, PALETTE, configure_page, initialize_session_state
@@ -21,6 +23,7 @@ from scm_dashboard_v4.processing import (
     load_wip_from_incoming,
 )
 from scm_dashboard_v4.timeline import build_timeline
+from scm_dashboard_v4.sales import prepare_amazon_daily_sales
 
 configure_page()
 initialize_session_state()
@@ -384,6 +387,71 @@ else:
         f"prod{int(show_prod)}|tran{int(show_transit)}"
     )
     st.plotly_chart(fig, use_container_width=True, config={"displaylogo": False}, key=chart_key)
+
+# ==================== Amazon US Sales vs Inventory ====================
+amazon_centers = sorted({c for c in snap_long["center"].unique() if "amazon" in str(c).lower()})
+selected_amazon_centers = [c for c in centers_sel if c in amazon_centers]
+
+sales_series = prepare_amazon_daily_sales(
+    snap_long,
+    centers=selected_amazon_centers or amazon_centers,
+    skus=skus_sel,
+    rolling_window=7,
+)
+
+if not sales_series.empty:
+    sales_df = sales_series.frame
+    # This chart shows Amazon-related snapshot totals with derived sales deltas.
+    # Users can toggle individual traces (sales, inventory, rolling avg) via the legend.
+    st.divider()
+    st.subheader("Amazon US 일별 판매 vs. 재고")
+
+    chart = make_subplots(specs=[[{"secondary_y": True}]])
+    chart.add_trace(
+        go.Bar(
+            x=sales_df["date"],
+            y=sales_df["daily_sales"],
+            name="Daily Sales (EA)",
+            marker_color=PALETTE[0],
+        ),
+        secondary_y=False,
+    )
+    chart.add_trace(
+        go.Scatter(
+            x=sales_df["date"],
+            y=sales_df["inventory_qty"],
+            mode="lines+markers",
+            name="Amazon Inventory (EA)",
+            line=dict(color=PALETTE[1], width=2),
+        ),
+        secondary_y=True,
+    )
+
+    ma_cols = [c for c in sales_df.columns if c.startswith("sales_ma_")]
+    for idx, col in enumerate(ma_cols, start=2):
+        chart.add_trace(
+            go.Scatter(
+                x=sales_df["date"],
+                y=sales_df[col],
+                mode="lines",
+                name=f"{col.split('_')[-1]}-Day Avg Sales",
+                line=dict(color=PALETTE[(idx) % len(PALETTE)], dash="dash"),
+            ),
+            secondary_y=False,
+        )
+
+    chart.update_layout(
+        title="Amazon US 판매 및 재고 추이",
+        hovermode="x unified",
+        legend_title_text="Toggle Series",
+        margin=dict(l=20, r=20, t=60, b=20),
+    )
+    chart.update_yaxes(title_text="Daily Sales (EA)", secondary_y=False)
+    chart.update_yaxes(title_text="Inventory (EA)", secondary_y=True)
+    chart.update_xaxes(title_text="날짜")
+    chart.update_traces(hovertemplate="날짜: %{x|%Y-%m-%d}<br>값: %{y:,.0f}<extra>%{fullData.name}</extra>")
+
+    st.plotly_chart(chart, use_container_width=True, config={"displaylogo": False})
 
 # -------------------- Upcoming Arrivals (fixed) --------------------
 st.subheader("입고 예정 내역 (선택 센터/SKU)")


### PR DESCRIPTION
## Summary
- add a reusable helper that prepares Amazon inventory snapshots into daily sales metrics
- render a combined sales versus inventory chart in the modular Streamlit app with legend toggles and rolling averages

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'scm_dashboard_v4')*

------
https://chatgpt.com/codex/tasks/task_e_68ddd1e1678883288cd85e3a6bf53ff6