### PR TITLE
Add legacy alias for Amazon sales prep API

### DIFF
--- a/scm_dashboard_v4/sales.py
+++ b/scm_dashboard_v4/sales.py
@@ -89,3 +89,12 @@ def prepare_amazon_sales_series(
     return AmazonSalesResult(agg, center)
 
 
+prepare_amazon_daily_sales = prepare_amazon_sales_series
+
+
+__all__ = [
+    "AmazonSalesResult",
+    "prepare_amazon_sales_series",
+    "prepare_amazon_daily_sales",
+]
+


### PR DESCRIPTION
## Summary
- add the legacy `prepare_amazon_daily_sales` alias for callers still using the old import
- document the public sales helpers in `__all__`

## Testing
- pytest tests/test_sales.py
- streamlit run streamlit_scm_step_v4.py --server.headless true --server.port 8501

------
https://chatgpt.com/codex/tasks/task_e_68ddfa951464832887e010a68d1ce131