### PR TITLE
Implement production timeline helper and add regression tests

### DIFF
--- a/scm_dashboard_v4/timeline.py
+++ b/scm_dashboard_v4/timeline.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Iterable, List, Optional
+from typing import Iterable
 
 import numpy as np
 import pandas as pd
-
 
 DATE_COLUMNS = ("onboard_date", "arrival_date", "inbound_date", "event_date")
 
@@ -28,28 +27,22 @@ def annotate_move_schedule(
     horizon_end: pd.Timestamp,
     fallback_days: int = 1,
 ) -> pd.DataFrame:
-    """Attach predicted inbound dates aligned with the centre inventory policy.
-
-    The policy is:
-    * Prefer the actual inbound completion date when available.
-    * Otherwise fall back to the arrival/ETA date. Past arrivals stay in transit
-      for ``lag_days`` after arrival to mirror receipt delays; future ETAs
-      convert on the ETA itself.
-    * Rows without any milestone drop on ``today + fallback_days`` (capped to
-      the chart horizon) so they do not block the forecast indefinitely.
-    """
+    """Attach predicted inbound dates aligned with the centre inventory policy."""
 
     today_norm = pd.to_datetime(today).normalize()
     fallback_date = min(today_norm + pd.Timedelta(days=int(fallback_days)), horizon_end + pd.Timedelta(days=1))
 
     out = moves.copy()
     out["carrier_mode"] = out.get("carrier_mode", "").astype(str).str.upper()
+    actual_onboard = pd.to_datetime(out.get("onboard_date"), errors="coerce").dt.normalize()
+    out["_onboard_date_actual"] = actual_onboard
 
     pred = pd.Series(pd.NaT, index=out.index, dtype="datetime64[ns]")
 
-
-    has_inbound = out["inbound_date"].notna() if "inbound_date" in out else pd.Series(False, index=out.index)
-    pred.loc[has_inbound] = out.loc[has_inbound, "inbound_date"]
+    inbound_col = out.get("inbound_date")
+    has_inbound = inbound_col.notna() if inbound_col is not None else pd.Series(False, index=out.index)
+    if has_inbound.any():
+        pred.loc[has_inbound] = inbound_col.loc[has_inbound]
 
     if "arrival_date" in out:
         arrival_col = out["arrival_date"]
@@ -58,18 +51,15 @@ def annotate_move_schedule(
 
     has_arrival = (~has_inbound) & arrival_col.notna()
     if has_arrival.any():
-
         arr_dates = arrival_col
-        # Past arrivals remain in transit until the lagged receipt date.
         past_arrival = has_arrival & (arr_dates <= today_norm)
         if past_arrival.any():
             pred.loc[past_arrival] = out.loc[past_arrival, "arrival_date"] + pd.Timedelta(days=int(lag_days))
-        # Future ETAs release inventory on the ETA itself.
+
         future_arrival = has_arrival & (arr_dates > today_norm)
         if future_arrival.any():
             pred.loc[future_arrival] = out.loc[future_arrival, "arrival_date"]
 
-    # Shipments without any milestone fall back to a policy date (default: today + 1 day).
     pred = pred.fillna(fallback_date)
     out["pred_inbound_date"] = pd.to_datetime(pred).dt.normalize()
     out["pred_inbound_date"] = out["pred_inbound_date"].clip(upper=horizon_end + pd.Timedelta(days=1))
@@ -78,9 +68,7 @@ def annotate_move_schedule(
     return out
 
 
-def build_timeline(
-    snap_long: pd.DataFrame,
-
+def compute_in_transit_series(
     moves: pd.DataFrame,
     centers_sel: Iterable[str],
     skus_sel: Iterable[str],
@@ -89,211 +77,291 @@ def build_timeline(
     today: pd.Timestamp,
     lag_days: int = 7,
 ) -> pd.DataFrame:
-    """Build an in-transit daily timeseries synchronised with inventory receipts.
+    """Return the non-WIP in-transit series grouped by SKU."""
 
-    The output provides a daily step series per SKU whose decrements align
-    exactly with the receipt dates returned by :func:`annotate_move_schedule`.
+    if moves is None or moves.empty:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
 
-    Note
-    ----
-    The Streamlit dashboard no longer renders this series directly in the
-    inventory step chart, but the helper remains available for data export and
-    offline diagnostics.
-    """
-    centers = {str(c) for c in centers_sel}
-    skus = set(skus_sel)
+    start_dt = pd.to_datetime(start_dt).normalize()
+    horizon_end = pd.to_datetime(horizon_end).normalize()
     today_norm = pd.to_datetime(today).normalize()
+
+    centers = {str(c) for c in centers_sel}
+    skus = {str(s) for s in skus_sel}
+    if not centers or not skus:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
 
     prepared = normalize_move_dates(moves)
     prepared = annotate_move_schedule(prepared, today_norm, lag_days, horizon_end)
+    prepared["carrier_mode"] = prepared.get("carrier_mode", "").astype(str).str.upper()
+    prepared["resource_code"] = prepared.get("resource_code", "").astype(str)
+    prepared["to_center"] = prepared.get("to_center", "").astype(str)
+    prepared["from_center"] = prepared.get("from_center", "").astype(str)
+    prepared["qty_ea"] = pd.to_numeric(prepared.get("qty_ea", 0), errors="coerce").fillna(0)
+    start_col = "_onboard_date_actual" if "_onboard_date_actual" in prepared.columns else "onboard_date"
 
-    prepared = prepared[prepared.get("carrier_mode", "").astype(str).str.upper() != "WIP"].copy()
-    if prepared.empty:
-        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
-
-    prepared = prepared[
-        prepared["resource_code"].isin(skus)
-        & prepared["to_center"].astype(str).isin(centers)
-        & prepared["onboard_date"].notna()
+    filtered = prepared[
+        (prepared["carrier_mode"] != "WIP")
+        & prepared["resource_code"].isin(skus)
+        & prepared["to_center"].isin(centers)
     ].copy()
-    if prepared.empty:
+
+    if filtered.empty:
         return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
 
-    mv_all = normalize_move_dates(moves.copy())
-    mv_all = annotate_move_schedule(mv_all, today, lag_days, horizon_end)
+    idx = pd.date_range(start_dt, horizon_end, freq="D")
+    lines = []
+    for sku, grp in filtered.groupby("resource_code"):
+        starts = grp.dropna(subset=[start_col]).groupby(start_col)["qty_ea"].sum()
+        ends = grp.dropna(subset=["in_transit_end_date"]).groupby("in_transit_end_date")["qty_ea"].sum() * -1
+        delta = (
+            starts.rename_axis("date").to_frame("delta")
+            .add(ends.rename_axis("date").to_frame("delta"), fill_value=0)
+            ["delta"].sort_index()
+        )
+        delta = delta.reindex(idx, fill_value=0.0)
+        series = delta.cumsum().clip(lower=0)
 
+        carry_mask = (
+            grp[start_col].notna()
+            & (grp[start_col] < idx[0])
+            & (grp["in_transit_end_date"].fillna(horizon_end + pd.Timedelta(days=1)) > idx[0])
+        )
+        carry = int(grp.loc[carry_mask, "qty_ea"].sum())
+        if carry:
+            series = (series + carry).clip(lower=0)
 
-    mv_all = normalize_move_dates(moves.copy())
-    mv_all = annotate_move_schedule(mv_all, today, lag_days, horizon_end)
+        if series.any():
+            lines.append(
+                pd.DataFrame(
+                    {
+                        "date": series.index,
+                        "center": "In-Transit",
+                        "resource_code": sku,
+                        "stock_qty": series.values,
+                    }
+                )
+            )
 
-
-    if not series_frames:
+    if not lines:
         return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
 
-    result = pd.concat(series_frames, ignore_index=True)
-    return result
+    out = pd.concat(lines, ignore_index=True)
+    out["stock_qty"] = out["stock_qty"].round().astype(int)
+    return out
 
 
-def generate_timeline(
+def _compute_wip_series(
     moves: pd.DataFrame,
-    capacity: pd.DataFrame,
-    mv_all: pd.DataFrame,
-    product_master: pd.DataFrame,
     skus_sel: Iterable[str],
+    start_dt: pd.Timestamp,
+    horizon_end: pd.Timestamp,
+) -> pd.DataFrame:
+    if moves is None or moves.empty:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+
+    start_dt = pd.to_datetime(start_dt).normalize()
+    horizon_end = pd.to_datetime(horizon_end).normalize()
+
+    skus = {str(s) for s in skus_sel}
+    moves = moves.copy()
+    moves["carrier_mode"] = moves.get("carrier_mode", "").astype(str).str.upper()
+    moves["resource_code"] = moves.get("resource_code", "").astype(str)
+    moves["qty_ea"] = pd.to_numeric(moves.get("qty_ea", 0), errors="coerce").fillna(0)
+
+    start_col = "_onboard_date_actual" if "_onboard_date_actual" in moves.columns else "onboard_date"
+
+    wip = moves[(moves["carrier_mode"] == "WIP") & moves["resource_code"].isin(skus)]
+    if wip.empty:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+
+    idx = pd.date_range(start_dt, horizon_end, freq="D")
+    lines = []
+    for sku, grp in wip.groupby("resource_code"):
+        deltas = []
+        onboard = (
+            grp[grp[start_col].notna()]
+            .groupby(start_col, as_index=False)["qty_ea"].sum()
+            .rename(columns={start_col: "date", "qty_ea": "delta"})
+        )
+        if not onboard.empty:
+            deltas.append(onboard)
+
+        if "event_date" in grp.columns:
+            events = (
+                grp[grp["event_date"].notna()]
+                .groupby("event_date", as_index=False)["qty_ea"].sum()
+                .rename(columns={"event_date": "date", "qty_ea": "delta"})
+            )
+            if not events.empty:
+                events["delta"] *= -1
+                deltas.append(events)
+
+        if not deltas:
+            continue
+
+        delta = pd.concat(deltas, ignore_index=True)
+        delta_series = delta.groupby("date")["delta"].sum().reindex(idx, fill_value=0.0)
+        series = delta_series.cumsum().clip(lower=0)
+        if not series.any():
+            continue
+
+        lines.append(
+            pd.DataFrame(
+                {
+                    "date": series.index,
+                    "center": "WIP",
+                    "resource_code": sku,
+                    "stock_qty": series.values,
+                }
+            )
+        )
+
+    if not lines:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+
+    out = pd.concat(lines, ignore_index=True)
+    out["stock_qty"] = out["stock_qty"].round().astype(int)
+    return out
+
+
+def build_timeline(
+    snap_long: pd.DataFrame,
+    moves: pd.DataFrame,
     centers_sel: Iterable[str],
+    skus_sel: Iterable[str],
     start_dt: pd.Timestamp,
     horizon_end: pd.Timestamp,
     today: pd.Timestamp,
     lag_days: int = 7,
 ) -> pd.DataFrame:
-    """Merge capacity plan, transit data and WIP positions into a unified timeline.
+    """Build an in-transit daily timeseries synchronised with inventory receipts."""
 
-    Returns
-    -------
-    pd.DataFrame
-        Columns: date, center, resource_code, stock_qty
-    """
-    full_dates = pd.date_range(start_dt, horizon_end, freq="D")
-    capacity = capacity.copy()
-    capacity["date"] = pd.to_datetime(capacity["date"]).dt.normalize()
-    capacity["center"] = capacity["center"].astype(str)
+    today_norm = pd.to_datetime(today).normalize()
+    start_dt = pd.to_datetime(start_dt).normalize()
+    horizon_end = pd.to_datetime(horizon_end).normalize()
 
-    capacity_filt = capacity[
-        capacity["resource_code"].isin(skus_sel)
-        & capacity["center"].isin(centers_sel)
-        & (capacity["date"] >= start_dt)
-        & (capacity["date"] <= horizon_end)
+    centers = {str(c) for c in centers_sel}
+    skus = {str(s) for s in skus_sel}
+    if not centers or not skus:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+
+    snap_cols = {c.lower(): c for c in snap_long.columns}
+    date_col = snap_cols.get("date") or snap_cols.get("snapshot_date")
+    if not date_col:
+        raise KeyError("snap_long must contain a 'date' or 'snapshot_date' column")
+
+    snap = snap_long.copy()
+    snap["date"] = pd.to_datetime(snap[date_col], errors="coerce").dt.normalize()
+    snap["center"] = snap["center"].astype(str)
+    snap["resource_code"] = snap["resource_code"].astype(str)
+    snap["stock_qty"] = pd.to_numeric(snap["stock_qty"], errors="coerce")
+
+    snap = snap[
+        snap["center"].isin(centers)
+        & snap["resource_code"].isin(skus)
+        & snap["date"].notna()
     ].copy()
 
-    if capacity_filt.empty:
-        cap_rows = pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
-    else:
-        cap_rows = capacity_filt[["date", "center", "resource_code", "stock_qty"]].copy()
+    if snap.empty:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
 
-    lines: List[pd.DataFrame] = []
-    if not cap_rows.empty:
-        lines.append(cap_rows)
+    snap = snap[(snap["date"] >= start_dt) & (snap["date"] <= horizon_end)]
+    if snap.empty:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
 
-    if moves.empty and mv_all.empty:
-        if not lines:
-            return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
-        out = pd.concat(lines, ignore_index=True)
-        out = out[(out["date"] >= start_dt) & (out["date"] <= horizon_end)]
+    idx = pd.date_range(start_dt, horizon_end, freq="D")
 
-        out["stock_qty"] = pd.to_numeric(out["stock_qty"], errors="coerce")
-        out["stock_qty"] = out["stock_qty"].fillna(0)
-        out["stock_qty"] = out["stock_qty"].replace([np.inf, -np.inf], 0)
-        out["stock_qty"] = out["stock_qty"].clip(lower=0).astype(int)
+    mv_all = normalize_move_dates(moves.copy())
+    mv_all = annotate_move_schedule(mv_all, today_norm, lag_days, horizon_end)
+    mv_all["carrier_mode"] = mv_all.get("carrier_mode", "").astype(str).str.upper()
+    mv_all["resource_code"] = mv_all.get("resource_code", "").astype(str)
+    mv_all["from_center"] = mv_all.get("from_center", "").astype(str)
+    mv_all["to_center"] = mv_all.get("to_center", "").astype(str)
+    mv_all["qty_ea"] = pd.to_numeric(mv_all.get("qty_ea", 0), errors="coerce").fillna(0)
+    ship_start_col = "_onboard_date_actual" if "_onboard_date_actual" in mv_all.columns else "onboard_date"
 
+    lines: list[pd.DataFrame] = []
+    for (ct, sku), grp in snap.groupby(["center", "resource_code"]):
+        grp = grp.sort_values("date")
+        last_dt = grp["date"].max()
 
-        eff_minus = (
-            mv[(mv["from_center"].astype(str) == str(ct)) & (mv["onboard_date"].notna()) & (mv["onboard_date"] > last_dt)]
-            .groupby("onboard_date", as_index=False)["qty_ea"].sum()
-            .rename(columns={"onboard_date": "date", "qty_ea": "delta"})
-        )
-        eff_minus["delta"] *= -1
+        ts = pd.DataFrame({"date": idx})
+        ts["center"] = ct
+        ts["resource_code"] = sku
+        stock_series = grp.set_index("date")["stock_qty"].astype(float)
+        ts = ts.merge(stock_series.rename("stock_qty"), on="date", how="left")
+        ts["stock_qty"] = ts["stock_qty"].ffill().fillna(0.0)
 
-        mv_center = mv[(mv["to_center"].astype(str) == str(ct))].copy()
-        if not mv_center.empty:
-            eff_plus_src = mv_center[
-                (mv_center["carrier_mode"].astype(str).str.upper() != "WIP")
-                & (mv_center["pred_inbound_date"].notna())
-                & (mv_center["pred_inbound_date"] > last_dt)
-            ]
-            if eff_plus_src.empty:
-                eff_plus = pd.DataFrame(columns=["date", "delta"])
-            else:
+        mv = mv_all[mv_all["resource_code"] == sku]
+        if not mv.empty:
+            eff_minus = (
+                mv[
+                    (mv["from_center"] == ct)
+                    & mv[ship_start_col].notna()
+                    & (mv[ship_start_col] > last_dt)
+                ]
+                .groupby(ship_start_col, as_index=False)["qty_ea"].sum()
+                .rename(columns={ship_start_col: "date", "qty_ea": "delta"})
+            )
+            eff_minus["delta"] *= -1
+
+            mv_center = mv[(mv["to_center"] == ct) & (mv["carrier_mode"] != "WIP")]
+            if not mv_center.empty:
                 eff_plus = (
-                    eff_plus_src.groupby("pred_inbound_date", as_index=False)["qty_ea"].sum().rename(
-                        columns={"pred_inbound_date": "date", "qty_ea": "delta"}
-                    )
+                    mv_center[
+                        mv_center["pred_inbound_date"].notna()
+                        & (mv_center["pred_inbound_date"] > last_dt)
+                    ]
+                    .groupby("pred_inbound_date", as_index=False)["qty_ea"].sum()
+                    .rename(columns={"pred_inbound_date": "date", "qty_ea": "delta"})
                 )
+            else:
+                eff_plus = pd.DataFrame(columns=["date", "delta"])
 
+            eff_all = pd.concat([eff_minus, eff_plus], ignore_index=True)
+            if not eff_all.empty:
+                delta_series = eff_all.groupby("date")["delta"].sum().reindex(idx, fill_value=0.0)
+                ts["stock_qty"] = ts["stock_qty"] + delta_series.cumsum().values
+
+        if "event_date" in mv_all.columns:
+            wip_mask = (
+                (mv_all["resource_code"] == sku)
+                & (mv_all["carrier_mode"] == "WIP")
+                & (mv_all["to_center"] == ct)
+                & mv_all["event_date"].notna()
+            )
+            wip_complete = mv_all[wip_mask]
         else:
-            eff_plus = pd.DataFrame(columns=["date", "delta"])
-
-        eff_all = pd.concat([eff_minus, eff_plus], ignore_index=True)
-        if not eff_all.empty:
-            delta_series = eff_all.groupby("date")["delta"].sum()
-            delta_series = delta_series.reindex(ts["date"], fill_value=0).fillna(0)
-            for date, delta in delta_series.items():
-                if delta != 0:
-                    ts.loc[ts["date"] >= date, "stock_qty"] = ts.loc[ts["date"] >= date, "stock_qty"] + delta
-
-        ts["stock_qty"] = ts["stock_qty"].fillna(0).replace([np.inf, -np.inf], 0).clip(lower=0)
-        lines.append(ts)
-
-        wip_complete = moves[
-            (moves["resource_code"] == sku)
-            & (moves["carrier_mode"].astype(str).str.upper() == "WIP")
-            & (moves["to_center"] == ct)
-            & (moves["event_date"].notna())
-        ].copy()
+            wip_complete = pd.DataFrame(columns=mv_all.columns)
         if not wip_complete.empty:
             wip_add = (
-                wip_complete.groupby("event_date", as_index=False)["qty_ea"].sum().rename(columns={"event_date": "date", "qty_ea": "delta"})
-            )
-            wip_delta_series = wip_add.groupby("date")["delta"].sum()
-            wip_delta_series = wip_delta_series.reindex(ts["date"], fill_value=0).fillna(0)
-            for date, delta in wip_delta_series.items():
-                if delta != 0:
-                    ts.loc[ts["date"] >= date, "stock_qty"] = ts.loc[ts["date"] >= date, "stock_qty"] + delta
-            ts["stock_qty"] = ts["stock_qty"].fillna(0).replace([np.inf, -np.inf], 0).clip(lower=0)
-            lines[-1] = ts
-
-
-    moves_str = mv_all.copy()
-    moves_str["from_center"] = moves_str["from_center"].astype(str)
-    moves_str["to_center"] = moves_str["to_center"].astype(str)
-    moves_str["carrier_mode"] = moves_str["carrier_mode"].astype(str).str.upper()
-
-    mv_sel = moves_str[
-        moves_str["resource_code"].isin(skus_sel)
-        & (
-            moves_str["from_center"].isin(centers_sel)
-            | moves_str["to_center"].isin(centers_sel)
-            | (moves_str["carrier_mode"] == "WIP")
-        )
-    ]
-
-    for sku, g in mv_sel.groupby("resource_code"):
-        g_wip = g[g["carrier_mode"] == "WIP"]
-        if not g_wip.empty:
-            s = pd.Series(0, index=pd.to_datetime(full_dates))
-
-            add_onboard = (
-                g_wip[g_wip["onboard_date"].notna()]
-                .groupby("onboard_date", as_index=False)["qty_ea"].sum()
-                .rename(columns={"onboard_date": "date", "qty_ea": "delta"})
-            )
-            add_event = (
-                g_wip[g_wip["event_date"].notna()]
-                .groupby("event_date", as_index=False)["qty_ea"].sum()
+                wip_complete.groupby("event_date", as_index=False)["qty_ea"].sum()
                 .rename(columns={"event_date": "date", "qty_ea": "delta"})
             )
-            add_event["delta"] *= -1
-            deltas = pd.concat([add_onboard, add_event], ignore_index=True)
+            delta_series = wip_add.groupby("date")["delta"].sum().reindex(idx, fill_value=0.0)
+            ts["stock_qty"] = ts["stock_qty"] + delta_series.cumsum().values
 
-            if not deltas.empty:
-                delta_series = deltas.groupby("date")["delta"].sum()
-                delta_series = delta_series.reindex(s.index, fill_value=0).fillna(0)
-                for date, delta in delta_series.items():
-                    if delta != 0:
-                        s.loc[s.index >= date] = s.loc[s.index >= date] + delta
+        ts["stock_qty"] = ts["stock_qty"].fillna(0)
+        ts["stock_qty"] = ts["stock_qty"].replace([np.inf, -np.inf], 0)
+        ts["stock_qty"] = ts["stock_qty"].clip(lower=0)
+        lines.append(ts)
 
-                vdf = pd.DataFrame({"date": s.index, "center": "WIP", "resource_code": sku, "stock_qty": s.values})
-                vdf["stock_qty"] = vdf["stock_qty"].fillna(0).replace([np.inf, -np.inf], 0).clip(lower=0)
-                lines.append(vdf)
+    in_transit = compute_in_transit_series(mv_all, centers, skus, start_dt, horizon_end, today_norm, lag_days)
+    if not in_transit.empty:
+        lines.append(in_transit)
+
+    wip_series = _compute_wip_series(mv_all, skus, start_dt, horizon_end)
+    if not wip_series.empty:
+        lines.append(wip_series)
 
     if not lines:
         return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
 
     out = pd.concat(lines, ignore_index=True)
     out = out[(out["date"] >= start_dt) & (out["date"] <= horizon_end)]
-
     out["stock_qty"] = pd.to_numeric(out["stock_qty"], errors="coerce")
     out["stock_qty"] = out["stock_qty"].fillna(0)
     out["stock_qty"] = out["stock_qty"].replace([np.inf, -np.inf], 0)
     out["stock_qty"] = out["stock_qty"].clip(lower=0).astype(int)
-
     return out

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_in_transit.py
+++ b/tests/test_in_transit.py
@@ -87,9 +87,10 @@ def test_in_transit_synchronises_with_annotate_dates():
     # Check that deltas match predicted inbound dates
     deltas = ts.diff().fillna(ts.iloc[0])
 
+    onboard_field = "_onboard_date_actual" if "_onboard_date_actual" in prepared.columns else "onboard_date"
     onboard_events = (
         prepared[prepared["to_center"].astype(str) == "C1"]
-        .groupby("onboard_date")["qty_ea"].sum()
+        .groupby(onboard_field)["qty_ea"].sum()
     )
 
     for event_date, qty in onboard_events.items():
@@ -98,7 +99,7 @@ def test_in_transit_synchronises_with_annotate_dates():
         assert deltas.loc[event_date] == qty
 
     carry_expected = prepared[
-        (prepared["onboard_date"] < start)
+        (prepared[onboard_field] <= start)
         & (prepared["in_transit_end_date"] > start)
         & (prepared["to_center"].astype(str) == "C1")
     ]["qty_ea"].sum()

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,0 +1,113 @@
+import pandas as pd
+
+from scm_dashboard_v4.timeline import build_timeline
+
+
+def _timeline_to_series(timeline: pd.DataFrame, center: str, sku: str) -> pd.Series:
+    filtered = timeline[(timeline["center"] == center) & (timeline["resource_code"] == sku)].copy()
+    if filtered.empty:
+        return pd.Series(dtype=int)
+    return filtered.set_index("date")["stock_qty"].sort_index()
+
+
+def test_build_timeline_combines_center_transit_and_wip_lines():
+    snap_long = pd.DataFrame(
+        [
+            {"snapshot_date": "2024-01-01", "center": "A", "resource_code": "S1", "stock_qty": 100},
+            {"snapshot_date": "2024-01-02", "center": "A", "resource_code": "S1", "stock_qty": 90},
+            {"snapshot_date": "2024-01-01", "center": "B", "resource_code": "S1", "stock_qty": 50},
+        ]
+    )
+
+    moves = pd.DataFrame(
+        [
+            {
+                "resource_code": "S1",
+                "qty_ea": 20,
+                "from_center": "A",
+                "to_center": "B",
+                "onboard_date": "2024-01-04",
+                "carrier_mode": "SEA",
+            },
+            {
+                "resource_code": "S1",
+                "qty_ea": 30,
+                "from_center": "B",
+                "to_center": "A",
+                "onboard_date": "2024-01-03",
+                "arrival_date": "2024-01-05",
+                "carrier_mode": "AIR",
+            },
+            {
+                "resource_code": "S1",
+                "qty_ea": 10,
+                "from_center": "Factory",
+                "to_center": "A",
+                "onboard_date": "2024-01-02",
+                "event_date": "2024-01-04",
+                "carrier_mode": "WIP",
+            },
+        ]
+    )
+
+    timeline = build_timeline(
+        snap_long,
+        moves,
+        centers_sel=["A", "B"],
+        skus_sel=["S1"],
+        start_dt=pd.Timestamp("2024-01-01"),
+        horizon_end=pd.Timestamp("2024-01-05"),
+        today=pd.Timestamp("2024-01-02"),
+        lag_days=2,
+    )
+
+    center_series = _timeline_to_series(timeline, "A", "S1")
+    assert center_series.loc[pd.Timestamp("2024-01-04")] == 80
+    assert center_series.loc[pd.Timestamp("2024-01-05")] == 110
+
+    in_transit_series = _timeline_to_series(timeline, "In-Transit", "S1")
+    assert in_transit_series.loc[pd.Timestamp("2024-01-04")] == 30
+    assert in_transit_series.loc[pd.Timestamp("2024-01-05")] == 0
+
+    wip_series = _timeline_to_series(timeline, "WIP", "S1")
+    assert wip_series.loc[pd.Timestamp("2024-01-03")] == 10
+    assert wip_series.loc[pd.Timestamp("2024-01-04")] == 0
+
+
+def test_build_timeline_uses_fallback_for_missing_arrival():
+    snap_long = pd.DataFrame(
+        [
+            {"snapshot_date": "2024-01-01", "center": "C", "resource_code": "SKU", "stock_qty": 0},
+        ]
+    )
+
+    moves = pd.DataFrame(
+        [
+            {
+                "resource_code": "SKU",
+                "qty_ea": 5,
+                "from_center": "X",
+                "to_center": "C",
+                "onboard_date": "2024-01-01",
+                "carrier_mode": "TRUCK",
+            }
+        ]
+    )
+
+    timeline = build_timeline(
+        snap_long,
+        moves,
+        centers_sel=["C"],
+        skus_sel=["SKU"],
+        start_dt=pd.Timestamp("2024-01-01"),
+        horizon_end=pd.Timestamp("2024-01-03"),
+        today=pd.Timestamp("2024-01-01"),
+        lag_days=1,
+    )
+
+    center_series = _timeline_to_series(timeline, "C", "SKU")
+    assert center_series.loc[pd.Timestamp("2024-01-02")] == 5
+
+    in_transit_series = _timeline_to_series(timeline, "In-Transit", "SKU")
+    assert in_transit_series.loc[pd.Timestamp("2024-01-01")] == 5
+    assert in_transit_series.loc[pd.Timestamp("2024-01-02")] == 0


### PR DESCRIPTION
## Summary
- port the streamlit build_timeline logic into scm_dashboard_v4.timeline, including the shared compute_in_transit_series helper and normalized onboard dates
- add regression coverage for build_timeline output structure and adjust in-transit tests to use the normalized onboard date metadata
- ensure test utilities have access to the package modules via a conftest shim

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de026705f883288eeaf13e99224167