### PR TITLE
Add Streamlit entry point for v5 pipeline

### DIFF
--- a/scm_dashboard_v4/timeline.py
+++ b/scm_dashboard_v4/timeline.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Iterable, List, Optional
+from typing import Iterable
 
 import numpy as np
 import pandas as pd
-
 
 DATE_COLUMNS = ("onboard_date", "arrival_date", "inbound_date", "event_date")
 
@@ -28,28 +27,22 @@ def annotate_move_schedule(
     horizon_end: pd.Timestamp,
     fallback_days: int = 1,
 ) -> pd.DataFrame:
-    """Attach predicted inbound dates aligned with the centre inventory policy.
-
-    The policy is:
-    * Prefer the actual inbound completion date when available.
-    * Otherwise fall back to the arrival/ETA date. Past arrivals stay in transit
-      for ``lag_days`` after arrival to mirror receipt delays; future ETAs
-      convert on the ETA itself.
-    * Rows without any milestone drop on ``today + fallback_days`` (capped to
-      the chart horizon) so they do not block the forecast indefinitely.
-    """
+    """Attach predicted inbound dates aligned with the centre inventory policy."""
 
     today_norm = pd.to_datetime(today).normalize()
     fallback_date = min(today_norm + pd.Timedelta(days=int(fallback_days)), horizon_end + pd.Timedelta(days=1))
 
     out = moves.copy()
     out["carrier_mode"] = out.get("carrier_mode", "").astype(str).str.upper()
+    actual_onboard = pd.to_datetime(out.get("onboard_date"), errors="coerce").dt.normalize()
+    out["_onboard_date_actual"] = actual_onboard
 
     pred = pd.Series(pd.NaT, index=out.index, dtype="datetime64[ns]")
 
-
-    has_inbound = out["inbound_date"].notna() if "inbound_date" in out else pd.Series(False, index=out.index)
-    pred.loc[has_inbound] = out.loc[has_inbound, "inbound_date"]
+    inbound_col = out.get("inbound_date")
+    has_inbound = inbound_col.notna() if inbound_col is not None else pd.Series(False, index=out.index)
+    if has_inbound.any():
+        pred.loc[has_inbound] = inbound_col.loc[has_inbound]
 
     if "arrival_date" in out:
         arrival_col = out["arrival_date"]
@@ -58,18 +51,15 @@ def annotate_move_schedule(
 
     has_arrival = (~has_inbound) & arrival_col.notna()
     if has_arrival.any():
-
         arr_dates = arrival_col
-        # Past arrivals remain in transit until the lagged receipt date.
         past_arrival = has_arrival & (arr_dates <= today_norm)
         if past_arrival.any():
             pred.loc[past_arrival] = out.loc[past_arrival, "arrival_date"] + pd.Timedelta(days=int(lag_days))
-        # Future ETAs release inventory on the ETA itself.
+
         future_arrival = has_arrival & (arr_dates > today_norm)
         if future_arrival.any():
             pred.loc[future_arrival] = out.loc[future_arrival, "arrival_date"]
 
-    # Shipments without any milestone fall back to a policy date (default: today + 1 day).
     pred = pred.fillna(fallback_date)
     out["pred_inbound_date"] = pd.to_datetime(pred).dt.normalize()
     out["pred_inbound_date"] = out["pred_inbound_date"].clip(upper=horizon_end + pd.Timedelta(days=1))
@@ -78,9 +68,7 @@ def annotate_move_schedule(
     return out
 
 
-def build_timeline(
-    snap_long: pd.DataFrame,
-
+def compute_in_transit_series(
     moves: pd.DataFrame,
     centers_sel: Iterable[str],
     skus_sel: Iterable[str],
@@ -89,211 +77,291 @@ def build_timeline(
     today: pd.Timestamp,
     lag_days: int = 7,
 ) -> pd.DataFrame:
-    """Build an in-transit daily timeseries synchronised with inventory receipts.
+    """Return the non-WIP in-transit series grouped by SKU."""
 
-    The output provides a daily step series per SKU whose decrements align
-    exactly with the receipt dates returned by :func:`annotate_move_schedule`.
+    if moves is None or moves.empty:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
 
-    Note
-    ----
-    The Streamlit dashboard no longer renders this series directly in the
-    inventory step chart, but the helper remains available for data export and
-    offline diagnostics.
-    """
-    centers = {str(c) for c in centers_sel}
-    skus = set(skus_sel)
+    start_dt = pd.to_datetime(start_dt).normalize()
+    horizon_end = pd.to_datetime(horizon_end).normalize()
     today_norm = pd.to_datetime(today).normalize()
+
+    centers = {str(c) for c in centers_sel}
+    skus = {str(s) for s in skus_sel}
+    if not centers or not skus:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
 
     prepared = normalize_move_dates(moves)
     prepared = annotate_move_schedule(prepared, today_norm, lag_days, horizon_end)
+    prepared["carrier_mode"] = prepared.get("carrier_mode", "").astype(str).str.upper()
+    prepared["resource_code"] = prepared.get("resource_code", "").astype(str)
+    prepared["to_center"] = prepared.get("to_center", "").astype(str)
+    prepared["from_center"] = prepared.get("from_center", "").astype(str)
+    prepared["qty_ea"] = pd.to_numeric(prepared.get("qty_ea", 0), errors="coerce").fillna(0)
+    start_col = "_onboard_date_actual" if "_onboard_date_actual" in prepared.columns else "onboard_date"
 
-    prepared = prepared[prepared.get("carrier_mode", "").astype(str).str.upper() != "WIP"].copy()
-    if prepared.empty:
-        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
-
-    prepared = prepared[
-        prepared["resource_code"].isin(skus)
-        & prepared["to_center"].astype(str).isin(centers)
-        & prepared["onboard_date"].notna()
+    filtered = prepared[
+        (prepared["carrier_mode"] != "WIP")
+        & prepared["resource_code"].isin(skus)
+        & prepared["to_center"].isin(centers)
     ].copy()
-    if prepared.empty:
+
+    if filtered.empty:
         return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
 
-    mv_all = normalize_move_dates(moves.copy())
-    mv_all = annotate_move_schedule(mv_all, today, lag_days, horizon_end)
+    idx = pd.date_range(start_dt, horizon_end, freq="D")
+    lines = []
+    for sku, grp in filtered.groupby("resource_code"):
+        starts = grp.dropna(subset=[start_col]).groupby(start_col)["qty_ea"].sum()
+        ends = grp.dropna(subset=["in_transit_end_date"]).groupby("in_transit_end_date")["qty_ea"].sum() * -1
+        delta = (
+            starts.rename_axis("date").to_frame("delta")
+            .add(ends.rename_axis("date").to_frame("delta"), fill_value=0)
+            ["delta"].sort_index()
+        )
+        delta = delta.reindex(idx, fill_value=0.0)
+        series = delta.cumsum().clip(lower=0)
 
+        carry_mask = (
+            grp[start_col].notna()
+            & (grp[start_col] < idx[0])
+            & (grp["in_transit_end_date"].fillna(horizon_end + pd.Timedelta(days=1)) > idx[0])
+        )
+        carry = int(grp.loc[carry_mask, "qty_ea"].sum())
+        if carry:
+            series = (series + carry).clip(lower=0)
 
-    mv_all = normalize_move_dates(moves.copy())
-    mv_all = annotate_move_schedule(mv_all, today, lag_days, horizon_end)
+        if series.any():
+            lines.append(
+                pd.DataFrame(
+                    {
+                        "date": series.index,
+                        "center": "In-Transit",
+                        "resource_code": sku,
+                        "stock_qty": series.values,
+                    }
+                )
+            )
 
-
-    if not series_frames:
+    if not lines:
         return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
 
-    result = pd.concat(series_frames, ignore_index=True)
-    return result
+    out = pd.concat(lines, ignore_index=True)
+    out["stock_qty"] = out["stock_qty"].round().astype(int)
+    return out
 
 
-def generate_timeline(
+def _compute_wip_series(
     moves: pd.DataFrame,
-    capacity: pd.DataFrame,
-    mv_all: pd.DataFrame,
-    product_master: pd.DataFrame,
     skus_sel: Iterable[str],
+    start_dt: pd.Timestamp,
+    horizon_end: pd.Timestamp,
+) -> pd.DataFrame:
+    if moves is None or moves.empty:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+
+    start_dt = pd.to_datetime(start_dt).normalize()
+    horizon_end = pd.to_datetime(horizon_end).normalize()
+
+    skus = {str(s) for s in skus_sel}
+    moves = moves.copy()
+    moves["carrier_mode"] = moves.get("carrier_mode", "").astype(str).str.upper()
+    moves["resource_code"] = moves.get("resource_code", "").astype(str)
+    moves["qty_ea"] = pd.to_numeric(moves.get("qty_ea", 0), errors="coerce").fillna(0)
+
+    start_col = "_onboard_date_actual" if "_onboard_date_actual" in moves.columns else "onboard_date"
+
+    wip = moves[(moves["carrier_mode"] == "WIP") & moves["resource_code"].isin(skus)]
+    if wip.empty:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+
+    idx = pd.date_range(start_dt, horizon_end, freq="D")
+    lines = []
+    for sku, grp in wip.groupby("resource_code"):
+        deltas = []
+        onboard = (
+            grp[grp[start_col].notna()]
+            .groupby(start_col, as_index=False)["qty_ea"].sum()
+            .rename(columns={start_col: "date", "qty_ea": "delta"})
+        )
+        if not onboard.empty:
+            deltas.append(onboard)
+
+        if "event_date" in grp.columns:
+            events = (
+                grp[grp["event_date"].notna()]
+                .groupby("event_date", as_index=False)["qty_ea"].sum()
+                .rename(columns={"event_date": "date", "qty_ea": "delta"})
+            )
+            if not events.empty:
+                events["delta"] *= -1
+                deltas.append(events)
+
+        if not deltas:
+            continue
+
+        delta = pd.concat(deltas, ignore_index=True)
+        delta_series = delta.groupby("date")["delta"].sum().reindex(idx, fill_value=0.0)
+        series = delta_series.cumsum().clip(lower=0)
+        if not series.any():
+            continue
+
+        lines.append(
+            pd.DataFrame(
+                {
+                    "date": series.index,
+                    "center": "WIP",
+                    "resource_code": sku,
+                    "stock_qty": series.values,
+                }
+            )
+        )
+
+    if not lines:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+
+    out = pd.concat(lines, ignore_index=True)
+    out["stock_qty"] = out["stock_qty"].round().astype(int)
+    return out
+
+
+def build_timeline(
+    snap_long: pd.DataFrame,
+    moves: pd.DataFrame,
     centers_sel: Iterable[str],
+    skus_sel: Iterable[str],
     start_dt: pd.Timestamp,
     horizon_end: pd.Timestamp,
     today: pd.Timestamp,
     lag_days: int = 7,
 ) -> pd.DataFrame:
-    """Merge capacity plan, transit data and WIP positions into a unified timeline.
+    """Build an in-transit daily timeseries synchronised with inventory receipts."""
 
-    Returns
-    -------
-    pd.DataFrame
-        Columns: date, center, resource_code, stock_qty
-    """
-    full_dates = pd.date_range(start_dt, horizon_end, freq="D")
-    capacity = capacity.copy()
-    capacity["date"] = pd.to_datetime(capacity["date"]).dt.normalize()
-    capacity["center"] = capacity["center"].astype(str)
+    today_norm = pd.to_datetime(today).normalize()
+    start_dt = pd.to_datetime(start_dt).normalize()
+    horizon_end = pd.to_datetime(horizon_end).normalize()
 
-    capacity_filt = capacity[
-        capacity["resource_code"].isin(skus_sel)
-        & capacity["center"].isin(centers_sel)
-        & (capacity["date"] >= start_dt)
-        & (capacity["date"] <= horizon_end)
+    centers = {str(c) for c in centers_sel}
+    skus = {str(s) for s in skus_sel}
+    if not centers or not skus:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+
+    snap_cols = {c.lower(): c for c in snap_long.columns}
+    date_col = snap_cols.get("date") or snap_cols.get("snapshot_date")
+    if not date_col:
+        raise KeyError("snap_long must contain a 'date' or 'snapshot_date' column")
+
+    snap = snap_long.copy()
+    snap["date"] = pd.to_datetime(snap[date_col], errors="coerce").dt.normalize()
+    snap["center"] = snap["center"].astype(str)
+    snap["resource_code"] = snap["resource_code"].astype(str)
+    snap["stock_qty"] = pd.to_numeric(snap["stock_qty"], errors="coerce")
+
+    snap = snap[
+        snap["center"].isin(centers)
+        & snap["resource_code"].isin(skus)
+        & snap["date"].notna()
     ].copy()
 
-    if capacity_filt.empty:
-        cap_rows = pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
-    else:
-        cap_rows = capacity_filt[["date", "center", "resource_code", "stock_qty"]].copy()
+    if snap.empty:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
 
-    lines: List[pd.DataFrame] = []
-    if not cap_rows.empty:
-        lines.append(cap_rows)
+    snap = snap[(snap["date"] >= start_dt) & (snap["date"] <= horizon_end)]
+    if snap.empty:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
 
-    if moves.empty and mv_all.empty:
-        if not lines:
-            return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
-        out = pd.concat(lines, ignore_index=True)
-        out = out[(out["date"] >= start_dt) & (out["date"] <= horizon_end)]
+    idx = pd.date_range(start_dt, horizon_end, freq="D")
 
-        out["stock_qty"] = pd.to_numeric(out["stock_qty"], errors="coerce")
-        out["stock_qty"] = out["stock_qty"].fillna(0)
-        out["stock_qty"] = out["stock_qty"].replace([np.inf, -np.inf], 0)
-        out["stock_qty"] = out["stock_qty"].clip(lower=0).astype(int)
+    mv_all = normalize_move_dates(moves.copy())
+    mv_all = annotate_move_schedule(mv_all, today_norm, lag_days, horizon_end)
+    mv_all["carrier_mode"] = mv_all.get("carrier_mode", "").astype(str).str.upper()
+    mv_all["resource_code"] = mv_all.get("resource_code", "").astype(str)
+    mv_all["from_center"] = mv_all.get("from_center", "").astype(str)
+    mv_all["to_center"] = mv_all.get("to_center", "").astype(str)
+    mv_all["qty_ea"] = pd.to_numeric(mv_all.get("qty_ea", 0), errors="coerce").fillna(0)
+    ship_start_col = "_onboard_date_actual" if "_onboard_date_actual" in mv_all.columns else "onboard_date"
 
+    lines: list[pd.DataFrame] = []
+    for (ct, sku), grp in snap.groupby(["center", "resource_code"]):
+        grp = grp.sort_values("date")
+        last_dt = grp["date"].max()
 
-        eff_minus = (
-            mv[(mv["from_center"].astype(str) == str(ct)) & (mv["onboard_date"].notna()) & (mv["onboard_date"] > last_dt)]
-            .groupby("onboard_date", as_index=False)["qty_ea"].sum()
-            .rename(columns={"onboard_date": "date", "qty_ea": "delta"})
-        )
-        eff_minus["delta"] *= -1
+        ts = pd.DataFrame({"date": idx})
+        ts["center"] = ct
+        ts["resource_code"] = sku
+        stock_series = grp.set_index("date")["stock_qty"].astype(float)
+        ts = ts.merge(stock_series.rename("stock_qty"), on="date", how="left")
+        ts["stock_qty"] = ts["stock_qty"].ffill().fillna(0.0)
 
-        mv_center = mv[(mv["to_center"].astype(str) == str(ct))].copy()
-        if not mv_center.empty:
-            eff_plus_src = mv_center[
-                (mv_center["carrier_mode"].astype(str).str.upper() != "WIP")
-                & (mv_center["pred_inbound_date"].notna())
-                & (mv_center["pred_inbound_date"] > last_dt)
-            ]
-            if eff_plus_src.empty:
-                eff_plus = pd.DataFrame(columns=["date", "delta"])
-            else:
+        mv = mv_all[mv_all["resource_code"] == sku]
+        if not mv.empty:
+            eff_minus = (
+                mv[
+                    (mv["from_center"] == ct)
+                    & mv[ship_start_col].notna()
+                    & (mv[ship_start_col] > last_dt)
+                ]
+                .groupby(ship_start_col, as_index=False)["qty_ea"].sum()
+                .rename(columns={ship_start_col: "date", "qty_ea": "delta"})
+            )
+            eff_minus["delta"] *= -1
+
+            mv_center = mv[(mv["to_center"] == ct) & (mv["carrier_mode"] != "WIP")]
+            if not mv_center.empty:
                 eff_plus = (
-                    eff_plus_src.groupby("pred_inbound_date", as_index=False)["qty_ea"].sum().rename(
-                        columns={"pred_inbound_date": "date", "qty_ea": "delta"}
-                    )
+                    mv_center[
+                        mv_center["pred_inbound_date"].notna()
+                        & (mv_center["pred_inbound_date"] > last_dt)
+                    ]
+                    .groupby("pred_inbound_date", as_index=False)["qty_ea"].sum()
+                    .rename(columns={"pred_inbound_date": "date", "qty_ea": "delta"})
                 )
+            else:
+                eff_plus = pd.DataFrame(columns=["date", "delta"])
 
+            eff_all = pd.concat([eff_minus, eff_plus], ignore_index=True)
+            if not eff_all.empty:
+                delta_series = eff_all.groupby("date")["delta"].sum().reindex(idx, fill_value=0.0)
+                ts["stock_qty"] = ts["stock_qty"] + delta_series.cumsum().values
+
+        if "event_date" in mv_all.columns:
+            wip_mask = (
+                (mv_all["resource_code"] == sku)
+                & (mv_all["carrier_mode"] == "WIP")
+                & (mv_all["to_center"] == ct)
+                & mv_all["event_date"].notna()
+            )
+            wip_complete = mv_all[wip_mask]
         else:
-            eff_plus = pd.DataFrame(columns=["date", "delta"])
-
-        eff_all = pd.concat([eff_minus, eff_plus], ignore_index=True)
-        if not eff_all.empty:
-            delta_series = eff_all.groupby("date")["delta"].sum()
-            delta_series = delta_series.reindex(ts["date"], fill_value=0).fillna(0)
-            for date, delta in delta_series.items():
-                if delta != 0:
-                    ts.loc[ts["date"] >= date, "stock_qty"] = ts.loc[ts["date"] >= date, "stock_qty"] + delta
-
-        ts["stock_qty"] = ts["stock_qty"].fillna(0).replace([np.inf, -np.inf], 0).clip(lower=0)
-        lines.append(ts)
-
-        wip_complete = moves[
-            (moves["resource_code"] == sku)
-            & (moves["carrier_mode"].astype(str).str.upper() == "WIP")
-            & (moves["to_center"] == ct)
-            & (moves["event_date"].notna())
-        ].copy()
+            wip_complete = pd.DataFrame(columns=mv_all.columns)
         if not wip_complete.empty:
             wip_add = (
-                wip_complete.groupby("event_date", as_index=False)["qty_ea"].sum().rename(columns={"event_date": "date", "qty_ea": "delta"})
-            )
-            wip_delta_series = wip_add.groupby("date")["delta"].sum()
-            wip_delta_series = wip_delta_series.reindex(ts["date"], fill_value=0).fillna(0)
-            for date, delta in wip_delta_series.items():
-                if delta != 0:
-                    ts.loc[ts["date"] >= date, "stock_qty"] = ts.loc[ts["date"] >= date, "stock_qty"] + delta
-            ts["stock_qty"] = ts["stock_qty"].fillna(0).replace([np.inf, -np.inf], 0).clip(lower=0)
-            lines[-1] = ts
-
-
-    moves_str = mv_all.copy()
-    moves_str["from_center"] = moves_str["from_center"].astype(str)
-    moves_str["to_center"] = moves_str["to_center"].astype(str)
-    moves_str["carrier_mode"] = moves_str["carrier_mode"].astype(str).str.upper()
-
-    mv_sel = moves_str[
-        moves_str["resource_code"].isin(skus_sel)
-        & (
-            moves_str["from_center"].isin(centers_sel)
-            | moves_str["to_center"].isin(centers_sel)
-            | (moves_str["carrier_mode"] == "WIP")
-        )
-    ]
-
-    for sku, g in mv_sel.groupby("resource_code"):
-        g_wip = g[g["carrier_mode"] == "WIP"]
-        if not g_wip.empty:
-            s = pd.Series(0, index=pd.to_datetime(full_dates))
-
-            add_onboard = (
-                g_wip[g_wip["onboard_date"].notna()]
-                .groupby("onboard_date", as_index=False)["qty_ea"].sum()
-                .rename(columns={"onboard_date": "date", "qty_ea": "delta"})
-            )
-            add_event = (
-                g_wip[g_wip["event_date"].notna()]
-                .groupby("event_date", as_index=False)["qty_ea"].sum()
+                wip_complete.groupby("event_date", as_index=False)["qty_ea"].sum()
                 .rename(columns={"event_date": "date", "qty_ea": "delta"})
             )
-            add_event["delta"] *= -1
-            deltas = pd.concat([add_onboard, add_event], ignore_index=True)
+            delta_series = wip_add.groupby("date")["delta"].sum().reindex(idx, fill_value=0.0)
+            ts["stock_qty"] = ts["stock_qty"] + delta_series.cumsum().values
 
-            if not deltas.empty:
-                delta_series = deltas.groupby("date")["delta"].sum()
-                delta_series = delta_series.reindex(s.index, fill_value=0).fillna(0)
-                for date, delta in delta_series.items():
-                    if delta != 0:
-                        s.loc[s.index >= date] = s.loc[s.index >= date] + delta
+        ts["stock_qty"] = ts["stock_qty"].fillna(0)
+        ts["stock_qty"] = ts["stock_qty"].replace([np.inf, -np.inf], 0)
+        ts["stock_qty"] = ts["stock_qty"].clip(lower=0)
+        lines.append(ts)
 
-                vdf = pd.DataFrame({"date": s.index, "center": "WIP", "resource_code": sku, "stock_qty": s.values})
-                vdf["stock_qty"] = vdf["stock_qty"].fillna(0).replace([np.inf, -np.inf], 0).clip(lower=0)
-                lines.append(vdf)
+    in_transit = compute_in_transit_series(mv_all, centers, skus, start_dt, horizon_end, today_norm, lag_days)
+    if not in_transit.empty:
+        lines.append(in_transit)
+
+    wip_series = _compute_wip_series(mv_all, skus, start_dt, horizon_end)
+    if not wip_series.empty:
+        lines.append(wip_series)
 
     if not lines:
         return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
 
     out = pd.concat(lines, ignore_index=True)
     out = out[(out["date"] >= start_dt) & (out["date"] <= horizon_end)]
-
     out["stock_qty"] = pd.to_numeric(out["stock_qty"], errors="coerce")
     out["stock_qty"] = out["stock_qty"].fillna(0)
     out["stock_qty"] = out["stock_qty"].replace([np.inf, -np.inf], 0)
     out["stock_qty"] = out["stock_qty"].clip(lower=0).astype(int)
-
     return out

--- a/scm_dashboard_v5/__init__.py
+++ b/scm_dashboard_v5/__init__.py
@@ -1,0 +1,5 @@
+"""Restructured SCM dashboard package with modular data pipeline."""
+
+from .pipeline import BuildInputs, build_timeline_bundle
+
+__all__ = ["BuildInputs", "build_timeline_bundle"]

--- a/scm_dashboard_v5/analytics/__init__.py
+++ b/scm_dashboard_v5/analytics/__init__.py
@@ -1,0 +1,11 @@
+"""Analytics layer facade for SCM dashboard v5."""
+
+from .inventory import pivot_inventory_cost_from_raw
+from .kpi import kpi_breakdown_per_sku
+from .sales import prepare_amazon_sales_series
+
+__all__ = [
+    "pivot_inventory_cost_from_raw",
+    "kpi_breakdown_per_sku",
+    "prepare_amazon_sales_series",
+]

--- a/scm_dashboard_v5/analytics/inventory.py
+++ b/scm_dashboard_v5/analytics/inventory.py
@@ -1,0 +1,11 @@
+"""Analytics adapters exposing the v4 inventory helpers under the new structure."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from scm_dashboard_v4 import inventory as v4_inventory
+
+
+def pivot_inventory_cost_from_raw(raw: pd.DataFrame) -> pd.DataFrame:
+    return v4_inventory.pivot_inventory_cost_from_raw(raw)

--- a/scm_dashboard_v5/analytics/kpi.py
+++ b/scm_dashboard_v5/analytics/kpi.py
@@ -1,0 +1,11 @@
+"""KPI adapters that map to the existing v4 KPI calculators."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from scm_dashboard_v4 import kpi as v4_kpi
+
+
+def kpi_breakdown_per_sku(snapshot: pd.DataFrame, *, recent_days: int = 28) -> pd.DataFrame:
+    return v4_kpi.kpi_breakdown_per_sku(snapshot, recent_days=recent_days)

--- a/scm_dashboard_v5/analytics/sales.py
+++ b/scm_dashboard_v5/analytics/sales.py
@@ -1,0 +1,11 @@
+"""Sales adapters re-exporting the existing v4 series helpers."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from scm_dashboard_v4 import sales as v4_sales
+
+
+def prepare_amazon_sales_series(sales: pd.DataFrame) -> pd.DataFrame:
+    return v4_sales.prepare_amazon_sales_series(sales)

--- a/scm_dashboard_v5/data_sources/__init__.py
+++ b/scm_dashboard_v5/data_sources/__init__.py
@@ -1,0 +1,5 @@
+"""Data source abstractions for SCM dashboard v5."""
+
+from .loader import Loader, StaticFrameLoader
+
+__all__ = ["Loader", "StaticFrameLoader"]

--- a/scm_dashboard_v5/data_sources/loader.py
+++ b/scm_dashboard_v5/data_sources/loader.py
@@ -1,0 +1,25 @@
+"""Unified data loading interfaces for files and Google Sheets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import pandas as pd
+
+
+class Loader(Protocol):
+    """Simple protocol describing a load operation that returns a DataFrame."""
+
+    def load(self) -> pd.DataFrame:  # pragma: no cover - interface definition
+        ...
+
+
+@dataclass(frozen=True)
+class StaticFrameLoader:
+    """Loader implementation that simply returns an in-memory DataFrame."""
+
+    frame: pd.DataFrame
+
+    def load(self) -> pd.DataFrame:
+        return self.frame.copy()

--- a/scm_dashboard_v5/domain/__init__.py
+++ b/scm_dashboard_v5/domain/__init__.py
@@ -1,0 +1,12 @@
+"""Domain layer exports for SCM dashboard v5."""
+
+from .models import MoveTable, SnapshotTable, TimelineBundle
+from .normalization import normalize_moves, normalize_snapshot
+
+__all__ = [
+    "MoveTable",
+    "SnapshotTable",
+    "TimelineBundle",
+    "normalize_moves",
+    "normalize_snapshot",
+]

--- a/scm_dashboard_v5/domain/models.py
+++ b/scm_dashboard_v5/domain/models.py
@@ -1,0 +1,106 @@
+"""Domain models representing normalized SCM dashboard tables."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class SnapshotTable:
+    """Normalized view of the daily inventory snapshot feed."""
+
+    data: pd.DataFrame
+
+    @classmethod
+    def from_dataframe(
+        cls,
+        frame: pd.DataFrame,
+        *,
+        date_column: str = "date",
+        center_column: str = "center",
+        sku_column: str = "resource_code",
+        qty_column: str = "stock_qty",
+    ) -> "SnapshotTable":
+        snap = frame.copy()
+        if date_column not in snap.columns and "snapshot_date" in snap.columns:
+            date_column = "snapshot_date"
+        if date_column not in snap.columns:
+            raise KeyError("snapshot data must include a date or snapshot_date column")
+
+        snap["date"] = pd.to_datetime(snap[date_column], errors="coerce").dt.normalize()
+        snap["center"] = snap[center_column].astype(str)
+        snap["resource_code"] = snap[sku_column].astype(str)
+        snap["stock_qty"] = pd.to_numeric(snap[qty_column], errors="coerce")
+        snap = snap.dropna(subset=["date"])
+        return cls(snap[["date", "center", "resource_code", "stock_qty"]])
+
+    def filter(
+        self,
+        *,
+        centers: Iterable[str],
+        skus: Iterable[str],
+        start: pd.Timestamp,
+        end: pd.Timestamp,
+    ) -> pd.DataFrame:
+        centers_set = {str(c) for c in centers}
+        skus_set = {str(s) for s in skus}
+        if not centers_set or not skus_set:
+            return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+
+        start_dt = pd.to_datetime(start).normalize()
+        end_dt = pd.to_datetime(end).normalize()
+        filtered = self.data[
+            self.data["center"].isin(centers_set)
+            & self.data["resource_code"].isin(skus_set)
+            & (self.data["date"] >= start_dt)
+            & (self.data["date"] <= end_dt)
+        ]
+        if filtered.empty:
+            return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+        return filtered.copy()
+
+
+@dataclass(frozen=True)
+class MoveTable:
+    """Normalized movement table enriched with schedule metadata."""
+
+    data: pd.DataFrame
+
+    def filter(self, *, skus: Sequence[str]) -> pd.DataFrame:
+        skus_set = {str(s) for s in skus}
+        if not skus_set:
+            return pd.DataFrame(columns=self.data.columns)
+        return self.data[self.data["resource_code"].isin(skus_set)].copy()
+
+    def slice_by_center(
+        self,
+        *,
+        center: str,
+        include_wip: bool = True,
+    ) -> pd.DataFrame:
+        frame = self.data.copy()
+        mask = frame["to_center"].eq(str(center))
+        if not include_wip:
+            mask &= frame["carrier_mode"] != "WIP"
+        return frame[mask]
+
+
+@dataclass(frozen=True)
+class TimelineBundle:
+    """Grouped timeline outputs for centers, in-transit, and WIP lines."""
+
+    center_lines: pd.DataFrame
+    in_transit_lines: pd.DataFrame
+    wip_lines: pd.DataFrame
+
+    def concat(self) -> pd.DataFrame:
+        frames = [df for df in (self.center_lines, self.in_transit_lines, self.wip_lines) if not df.empty]
+        if not frames:
+            return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+        combined = pd.concat(frames, ignore_index=True)
+        combined["stock_qty"] = pd.to_numeric(combined["stock_qty"], errors="coerce").fillna(0)
+        combined["stock_qty"] = combined["stock_qty"].clip(lower=0).round().astype(int)
+        return combined

--- a/scm_dashboard_v5/domain/normalization.py
+++ b/scm_dashboard_v5/domain/normalization.py
@@ -1,0 +1,51 @@
+"""Data normalization helpers for the SCM dashboard domain objects."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import pandas as pd
+
+DATE_COLUMNS = ("onboard_date", "arrival_date", "inbound_date", "event_date")
+
+
+def normalize_dates(frame: pd.DataFrame, *, columns: Iterable[str] = DATE_COLUMNS) -> pd.DataFrame:
+    """Return a copy of *frame* with the specified date columns normalised to midnight."""
+
+    out = frame.copy()
+    for col in columns:
+        if col in out.columns:
+            out[col] = pd.to_datetime(out[col], errors="coerce").dt.normalize()
+    return out
+
+
+def normalize_moves(frame: pd.DataFrame) -> pd.DataFrame:
+    """Coerce core move columns to predictable dtypes."""
+
+    out = normalize_dates(frame)
+    out["carrier_mode"] = out.get("carrier_mode", "").astype(str).str.upper()
+    out["resource_code"] = out.get("resource_code", "").astype(str)
+    out["from_center"] = out.get("from_center", "").astype(str)
+    out["to_center"] = out.get("to_center", "").astype(str)
+    out["qty_ea"] = pd.to_numeric(out.get("qty_ea", 0), errors="coerce").fillna(0)
+    return out
+
+
+def normalize_snapshot(frame: pd.DataFrame) -> pd.DataFrame:
+    """Standardise snapshot schema for downstream consumers."""
+
+    out = frame.copy()
+    date_col = None
+    for candidate in ("date", "snapshot_date"):
+        if candidate in out.columns:
+            date_col = candidate
+            break
+    if not date_col:
+        raise KeyError("snapshot frame must include a 'date' or 'snapshot_date' column")
+
+    out["date"] = pd.to_datetime(out[date_col], errors="coerce").dt.normalize()
+    out["center"] = out.get("center", "").astype(str)
+    out["resource_code"] = out.get("resource_code", "").astype(str)
+    out["stock_qty"] = pd.to_numeric(out.get("stock_qty", 0), errors="coerce")
+    out = out.dropna(subset=["date"])
+    return out[["date", "center", "resource_code", "stock_qty"]]

--- a/scm_dashboard_v5/forecast/__init__.py
+++ b/scm_dashboard_v5/forecast/__init__.py
@@ -1,0 +1,5 @@
+"""Forecasting facade for SCM dashboard v5."""
+
+from .consumption import apply_consumption_with_events, estimate_daily_consumption
+
+__all__ = ["apply_consumption_with_events", "estimate_daily_consumption"]

--- a/scm_dashboard_v5/forecast/consumption.py
+++ b/scm_dashboard_v5/forecast/consumption.py
@@ -1,0 +1,30 @@
+"""Forecasting adapters that reuse the proven v4 consumption logic."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import pandas as pd
+
+from scm_dashboard_v4 import consumption as v4_consumption
+
+
+def estimate_daily_consumption(sales: pd.DataFrame, *, window: int = 28) -> pd.DataFrame:
+    """Delegate to the stable v4 estimator while keeping the new namespace."""
+
+    return v4_consumption.estimate_daily_consumption(sales, window=window)
+
+
+def apply_consumption_with_events(
+    timeline: pd.DataFrame,
+    events: pd.DataFrame,
+    *,
+    centers: Iterable[str],
+    skus: Iterable[str],
+) -> pd.DataFrame:
+    return v4_consumption.apply_consumption_with_events(
+        timeline,
+        events,
+        centers=list(centers),
+        skus=list(skus),
+    )

--- a/scm_dashboard_v5/pipeline.py
+++ b/scm_dashboard_v5/pipeline.py
@@ -1,0 +1,40 @@
+"""End-to-end orchestration helpers for the restructured SCM dashboard."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import pandas as pd
+
+from .planning.timeline import TimelineBuilder, TimelineContext, prepare_moves, prepare_snapshot
+
+
+@dataclass(frozen=True)
+class BuildInputs:
+    snapshot: pd.DataFrame
+    moves: pd.DataFrame
+
+
+def build_timeline_bundle(
+    inputs: BuildInputs,
+    *,
+    centers: Iterable[str],
+    skus: Iterable[str],
+    start: pd.Timestamp,
+    end: pd.Timestamp,
+    today: pd.Timestamp,
+    lag_days: int = 7,
+):
+    context = TimelineContext(
+        centers=list(centers),
+        skus=list(skus),
+        start=start,
+        end=end,
+        today=today,
+        lag_days=lag_days,
+    )
+    builder = TimelineBuilder(context)
+    snapshot_table = prepare_snapshot(inputs.snapshot)
+    move_table = prepare_moves(inputs.moves, context=context)
+    return builder.build(snapshot_table, move_table)

--- a/scm_dashboard_v5/planning/__init__.py
+++ b/scm_dashboard_v5/planning/__init__.py
@@ -1,0 +1,17 @@
+"""Planning layer exports for SCM dashboard v5."""
+
+from .timeline import TimelineBuilder, TimelineContext, prepare_moves, prepare_snapshot
+from .series import SeriesIndex, build_center_series, build_in_transit_series, build_wip_series
+from .schedule import annotate_move_schedule
+
+__all__ = [
+    "TimelineBuilder",
+    "TimelineContext",
+    "prepare_moves",
+    "prepare_snapshot",
+    "SeriesIndex",
+    "build_center_series",
+    "build_in_transit_series",
+    "build_wip_series",
+    "annotate_move_schedule",
+]

--- a/scm_dashboard_v5/planning/schedule.py
+++ b/scm_dashboard_v5/planning/schedule.py
@@ -1,0 +1,54 @@
+"""Scheduling helpers for inbound move projections."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from ..domain.normalization import normalize_dates
+
+
+def annotate_move_schedule(
+    moves: pd.DataFrame,
+    *,
+    today: pd.Timestamp,
+    lag_days: int,
+    horizon_end: pd.Timestamp,
+    fallback_days: int = 1,
+) -> pd.DataFrame:
+    """Attach predicted inbound dates aligned with the centre inventory policy."""
+
+    today_norm = pd.to_datetime(today).normalize()
+    horizon_end = pd.to_datetime(horizon_end).normalize()
+    fallback_date = min(
+        today_norm + pd.Timedelta(days=int(fallback_days)),
+        horizon_end + pd.Timedelta(days=1),
+    )
+
+    out = normalize_dates(moves)
+    out["carrier_mode"] = out.get("carrier_mode", "").astype(str).str.upper()
+    actual_onboard = pd.to_datetime(out.get("onboard_date"), errors="coerce").dt.normalize()
+    out["_onboard_date_actual"] = actual_onboard
+
+    pred = pd.Series(pd.NaT, index=out.index, dtype="datetime64[ns]")
+    inbound_col = out.get("inbound_date")
+    has_inbound = inbound_col.notna() if inbound_col is not None else pd.Series(False, index=out.index)
+    if has_inbound.any():
+        pred.loc[has_inbound] = inbound_col.loc[has_inbound]
+
+    arrival_col = out["arrival_date"] if "arrival_date" in out else pd.Series(pd.NaT, index=out.index)
+    has_arrival = (~has_inbound) & arrival_col.notna()
+    if has_arrival.any():
+        arr_dates = arrival_col
+        past_arrival = has_arrival & (arr_dates <= today_norm)
+        if past_arrival.any():
+            pred.loc[past_arrival] = out.loc[past_arrival, "arrival_date"] + pd.Timedelta(days=int(lag_days))
+
+        future_arrival = has_arrival & (arr_dates > today_norm)
+        if future_arrival.any():
+            pred.loc[future_arrival] = out.loc[future_arrival, "arrival_date"]
+
+    pred = pred.fillna(fallback_date)
+    out["pred_inbound_date"] = pd.to_datetime(pred).dt.normalize()
+    out["pred_inbound_date"] = out["pred_inbound_date"].clip(upper=horizon_end + pd.Timedelta(days=1))
+    out["in_transit_end_date"] = out["pred_inbound_date"]
+    return out

--- a/scm_dashboard_v5/planning/series.py
+++ b/scm_dashboard_v5/planning/series.py
@@ -1,0 +1,249 @@
+"""Series builders for centre, in-transit, and WIP timelines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class SeriesIndex:
+    start: pd.Timestamp
+    end: pd.Timestamp
+
+    @property
+    def range(self) -> pd.DatetimeIndex:
+        return pd.date_range(self.start, self.end, freq="D")
+
+
+def build_center_series(
+    snapshot: pd.DataFrame,
+    moves: pd.DataFrame,
+    *,
+    centers: Iterable[str],
+    skus: Iterable[str],
+    index: SeriesIndex,
+) -> pd.DataFrame:
+    centers_set = {str(c) for c in centers}
+    skus_set = {str(s) for s in skus}
+    if snapshot.empty or not centers_set or not skus_set:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+
+    idx = index.range
+    mv = moves.copy()
+    ship_start_col = "_onboard_date_actual" if "_onboard_date_actual" in mv.columns else "onboard_date"
+
+    lines = []
+    for (ct, sku), grp in snapshot.groupby(["center", "resource_code"]):
+        if ct not in centers_set or sku not in skus_set:
+            continue
+        grp = grp.sort_values("date")
+        last_dt = grp["date"].max()
+
+        ts = pd.DataFrame({"date": idx})
+        ts["center"] = ct
+        ts["resource_code"] = sku
+        stock_series = grp.set_index("date")["stock_qty"].astype(float)
+        ts = ts.merge(stock_series.rename("stock_qty"), on="date", how="left")
+        ts["stock_qty"] = ts["stock_qty"].ffill().fillna(0.0)
+
+        mv_sku = mv[mv["resource_code"] == sku]
+        if not mv_sku.empty:
+            eff_minus = (
+                mv_sku[
+                    (mv_sku["from_center"] == ct)
+                    & mv_sku[ship_start_col].notna()
+                    & (mv_sku[ship_start_col] > last_dt)
+                ]
+                .groupby(ship_start_col, as_index=False)["qty_ea"].sum()
+                .rename(columns={ship_start_col: "date", "qty_ea": "delta"})
+            )
+            eff_minus["delta"] *= -1
+
+            mv_center = mv_sku[(mv_sku["to_center"] == ct) & (mv_sku["carrier_mode"] != "WIP")]
+            if not mv_center.empty:
+                eff_plus = (
+                    mv_center[
+                        mv_center["pred_inbound_date"].notna()
+                        & (mv_center["pred_inbound_date"] > last_dt)
+                    ]
+                    .groupby("pred_inbound_date", as_index=False)["qty_ea"].sum()
+                    .rename(columns={"pred_inbound_date": "date", "qty_ea": "delta"})
+                )
+            else:
+                eff_plus = pd.DataFrame(columns=["date", "delta"])
+
+            eff_all = pd.concat([eff_minus, eff_plus], ignore_index=True)
+            if not eff_all.empty:
+                delta_series = eff_all.groupby("date")["delta"].sum().reindex(idx, fill_value=0.0)
+                ts["stock_qty"] = ts["stock_qty"] + delta_series.cumsum().values
+
+        if "event_date" in mv_sku.columns:
+            wip_mask = (
+                (mv_sku["carrier_mode"] == "WIP")
+                & (mv_sku["to_center"] == ct)
+                & mv_sku["event_date"].notna()
+            )
+            wip_complete = mv_sku[wip_mask]
+        else:
+            wip_complete = pd.DataFrame(columns=mv_sku.columns)
+        if not wip_complete.empty:
+            wip_add = (
+                wip_complete.groupby("event_date", as_index=False)["qty_ea"].sum()
+                .rename(columns={"event_date": "date", "qty_ea": "delta"})
+            )
+            delta_series = wip_add.groupby("date")["delta"].sum().reindex(idx, fill_value=0.0)
+            ts["stock_qty"] = ts["stock_qty"] + delta_series.cumsum().values
+
+        ts["stock_qty"] = ts["stock_qty"].fillna(0)
+        ts["stock_qty"] = ts["stock_qty"].replace([np.inf, -np.inf], 0)
+        ts["stock_qty"] = ts["stock_qty"].clip(lower=0)
+        lines.append(ts)
+
+    if not lines:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+    out = pd.concat(lines, ignore_index=True)
+    return out
+
+
+def build_in_transit_series(
+    moves: pd.DataFrame,
+    *,
+    centers: Iterable[str],
+    skus: Iterable[str],
+    index: SeriesIndex,
+    today: pd.Timestamp,
+    lag_days: int,
+) -> pd.DataFrame:
+    if moves.empty:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+
+    centers_set = {str(c) for c in centers}
+    skus_set = {str(s) for s in skus}
+    if not centers_set or not skus_set:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+
+    start_dt = index.start
+    horizon_end = index.end
+    idx = index.range
+    start_col = "_onboard_date_actual" if "_onboard_date_actual" in moves.columns else "onboard_date"
+
+    filtered = moves[
+        (moves["carrier_mode"] != "WIP")
+        & moves["resource_code"].isin(skus_set)
+        & moves["to_center"].isin(centers_set)
+    ].copy()
+    if filtered.empty:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+
+    lines = []
+    for sku, grp in filtered.groupby("resource_code"):
+        starts = grp.dropna(subset=[start_col]).groupby(start_col)["qty_ea"].sum()
+        ends = grp.dropna(subset=["in_transit_end_date"]).groupby("in_transit_end_date")["qty_ea"].sum() * -1
+        delta = (
+            starts.rename_axis("date").to_frame("delta")
+            .add(ends.rename_axis("date").to_frame("delta"), fill_value=0)
+            ["delta"].sort_index()
+        )
+        delta = delta.reindex(idx, fill_value=0.0)
+        series = delta.cumsum().clip(lower=0)
+
+        carry_mask = (
+            grp[start_col].notna()
+            & (grp[start_col] < idx[0])
+            & (grp["in_transit_end_date"].fillna(horizon_end + pd.Timedelta(days=1)) > idx[0])
+        )
+        carry = int(grp.loc[carry_mask, "qty_ea"].sum())
+        if carry:
+            series = (series + carry).clip(lower=0)
+
+        if series.any():
+            lines.append(
+                pd.DataFrame(
+                    {
+                        "date": series.index,
+                        "center": "In-Transit",
+                        "resource_code": sku,
+                        "stock_qty": series.values,
+                    }
+                )
+            )
+
+    if not lines:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+
+    out = pd.concat(lines, ignore_index=True)
+    out["stock_qty"] = out["stock_qty"].round().astype(int)
+    return out
+
+
+def build_wip_series(
+    moves: pd.DataFrame,
+    *,
+    skus: Iterable[str],
+    index: SeriesIndex,
+) -> pd.DataFrame:
+    if moves.empty:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+
+    skus_set = {str(s) for s in skus}
+    if not skus_set:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+
+    idx = index.range
+    start_col = "_onboard_date_actual" if "_onboard_date_actual" in moves.columns else "onboard_date"
+
+    wip = moves[(moves["carrier_mode"] == "WIP") & moves["resource_code"].isin(skus_set)]
+    if wip.empty:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+
+    lines = []
+    for sku, grp in wip.groupby("resource_code"):
+        deltas = []
+        onboard = (
+            grp[grp[start_col].notna()]
+            .groupby(start_col, as_index=False)["qty_ea"].sum()
+            .rename(columns={start_col: "date", "qty_ea": "delta"})
+        )
+        if not onboard.empty:
+            deltas.append(onboard)
+
+        if "event_date" in grp.columns:
+            events = (
+                grp[grp["event_date"].notna()]
+                .groupby("event_date", as_index=False)["qty_ea"].sum()
+                .rename(columns={"event_date": "date", "qty_ea": "delta"})
+            )
+            if not events.empty:
+                events["delta"] *= -1
+                deltas.append(events)
+
+        if not deltas:
+            continue
+
+        delta = pd.concat(deltas, ignore_index=True)
+        delta_series = delta.groupby("date")["delta"].sum().reindex(idx, fill_value=0.0)
+        series = delta_series.cumsum().clip(lower=0)
+        if not series.any():
+            continue
+
+        lines.append(
+            pd.DataFrame(
+                {
+                    "date": series.index,
+                    "center": "WIP",
+                    "resource_code": sku,
+                    "stock_qty": series.values,
+                }
+            )
+        )
+
+    if not lines:
+        return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+
+    out = pd.concat(lines, ignore_index=True)
+    out["stock_qty"] = out["stock_qty"].round().astype(int)
+    return out

--- a/scm_dashboard_v5/planning/timeline.py
+++ b/scm_dashboard_v5/planning/timeline.py
@@ -1,0 +1,98 @@
+"""High level orchestration for building dashboard timelines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import pandas as pd
+
+from ..domain.models import MoveTable, SnapshotTable, TimelineBundle
+from ..domain.normalization import normalize_moves, normalize_snapshot
+from .schedule import annotate_move_schedule
+from .series import SeriesIndex, build_center_series, build_in_transit_series, build_wip_series
+
+
+@dataclass(frozen=True)
+class TimelineContext:
+    centers: Iterable[str]
+    skus: Iterable[str]
+    start: pd.Timestamp
+    end: pd.Timestamp
+    today: pd.Timestamp
+    lag_days: int = 7
+
+    @property
+    def index(self) -> SeriesIndex:
+        return SeriesIndex(
+            start=pd.to_datetime(self.start).normalize(),
+            end=pd.to_datetime(self.end).normalize(),
+        )
+
+
+class TimelineBuilder:
+    """Constructs the centre, in-transit, and WIP stock time series."""
+
+    def __init__(self, context: TimelineContext) -> None:
+        self.context = context
+
+    def build(
+        self,
+        snapshot: SnapshotTable,
+        moves: MoveTable,
+    ) -> TimelineBundle:
+        index = self.context.index
+        centers = list(self.context.centers)
+        skus = list(self.context.skus)
+
+        center_lines = build_center_series(
+            snapshot=snapshot.filter(
+                centers=centers,
+                skus=skus,
+                start=index.start,
+                end=index.end,
+            ),
+            moves=moves.data,
+            centers=centers,
+            skus=skus,
+            index=index,
+        )
+
+        in_transit = build_in_transit_series(
+            moves=moves.data,
+            centers=centers,
+            skus=skus,
+            index=index,
+            today=self.context.today,
+            lag_days=self.context.lag_days,
+        )
+
+        wip = build_wip_series(
+            moves=moves.data,
+            skus=skus,
+            index=index,
+        )
+
+        return TimelineBundle(center_lines=center_lines, in_transit_lines=in_transit, wip_lines=wip)
+
+
+def prepare_moves(
+    moves: pd.DataFrame,
+    *,
+    context: TimelineContext,
+    fallback_days: int = 1,
+) -> MoveTable:
+    normalized = normalize_moves(moves)
+    scheduled = annotate_move_schedule(
+        normalized,
+        today=context.today,
+        lag_days=context.lag_days,
+        horizon_end=context.end,
+        fallback_days=fallback_days,
+    )
+    return MoveTable(scheduled)
+
+
+def prepare_snapshot(snapshot: pd.DataFrame) -> SnapshotTable:
+    normalized = normalize_snapshot(snapshot)
+    return SnapshotTable(normalized)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_in_transit.py
+++ b/tests/test_in_transit.py
@@ -87,9 +87,10 @@ def test_in_transit_synchronises_with_annotate_dates():
     # Check that deltas match predicted inbound dates
     deltas = ts.diff().fillna(ts.iloc[0])
 
+    onboard_field = "_onboard_date_actual" if "_onboard_date_actual" in prepared.columns else "onboard_date"
     onboard_events = (
         prepared[prepared["to_center"].astype(str) == "C1"]
-        .groupby("onboard_date")["qty_ea"].sum()
+        .groupby(onboard_field)["qty_ea"].sum()
     )
 
     for event_date, qty in onboard_events.items():
@@ -98,7 +99,7 @@ def test_in_transit_synchronises_with_annotate_dates():
         assert deltas.loc[event_date] == qty
 
     carry_expected = prepared[
-        (prepared["onboard_date"] < start)
+        (prepared[onboard_field] <= start)
         & (prepared["in_transit_end_date"] > start)
         & (prepared["to_center"].astype(str) == "C1")
     ]["qty_ea"].sum()

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,0 +1,113 @@
+import pandas as pd
+
+from scm_dashboard_v4.timeline import build_timeline
+
+
+def _timeline_to_series(timeline: pd.DataFrame, center: str, sku: str) -> pd.Series:
+    filtered = timeline[(timeline["center"] == center) & (timeline["resource_code"] == sku)].copy()
+    if filtered.empty:
+        return pd.Series(dtype=int)
+    return filtered.set_index("date")["stock_qty"].sort_index()
+
+
+def test_build_timeline_combines_center_transit_and_wip_lines():
+    snap_long = pd.DataFrame(
+        [
+            {"snapshot_date": "2024-01-01", "center": "A", "resource_code": "S1", "stock_qty": 100},
+            {"snapshot_date": "2024-01-02", "center": "A", "resource_code": "S1", "stock_qty": 90},
+            {"snapshot_date": "2024-01-01", "center": "B", "resource_code": "S1", "stock_qty": 50},
+        ]
+    )
+
+    moves = pd.DataFrame(
+        [
+            {
+                "resource_code": "S1",
+                "qty_ea": 20,
+                "from_center": "A",
+                "to_center": "B",
+                "onboard_date": "2024-01-04",
+                "carrier_mode": "SEA",
+            },
+            {
+                "resource_code": "S1",
+                "qty_ea": 30,
+                "from_center": "B",
+                "to_center": "A",
+                "onboard_date": "2024-01-03",
+                "arrival_date": "2024-01-05",
+                "carrier_mode": "AIR",
+            },
+            {
+                "resource_code": "S1",
+                "qty_ea": 10,
+                "from_center": "Factory",
+                "to_center": "A",
+                "onboard_date": "2024-01-02",
+                "event_date": "2024-01-04",
+                "carrier_mode": "WIP",
+            },
+        ]
+    )
+
+    timeline = build_timeline(
+        snap_long,
+        moves,
+        centers_sel=["A", "B"],
+        skus_sel=["S1"],
+        start_dt=pd.Timestamp("2024-01-01"),
+        horizon_end=pd.Timestamp("2024-01-05"),
+        today=pd.Timestamp("2024-01-02"),
+        lag_days=2,
+    )
+
+    center_series = _timeline_to_series(timeline, "A", "S1")
+    assert center_series.loc[pd.Timestamp("2024-01-04")] == 80
+    assert center_series.loc[pd.Timestamp("2024-01-05")] == 110
+
+    in_transit_series = _timeline_to_series(timeline, "In-Transit", "S1")
+    assert in_transit_series.loc[pd.Timestamp("2024-01-04")] == 30
+    assert in_transit_series.loc[pd.Timestamp("2024-01-05")] == 0
+
+    wip_series = _timeline_to_series(timeline, "WIP", "S1")
+    assert wip_series.loc[pd.Timestamp("2024-01-03")] == 10
+    assert wip_series.loc[pd.Timestamp("2024-01-04")] == 0
+
+
+def test_build_timeline_uses_fallback_for_missing_arrival():
+    snap_long = pd.DataFrame(
+        [
+            {"snapshot_date": "2024-01-01", "center": "C", "resource_code": "SKU", "stock_qty": 0},
+        ]
+    )
+
+    moves = pd.DataFrame(
+        [
+            {
+                "resource_code": "SKU",
+                "qty_ea": 5,
+                "from_center": "X",
+                "to_center": "C",
+                "onboard_date": "2024-01-01",
+                "carrier_mode": "TRUCK",
+            }
+        ]
+    )
+
+    timeline = build_timeline(
+        snap_long,
+        moves,
+        centers_sel=["C"],
+        skus_sel=["SKU"],
+        start_dt=pd.Timestamp("2024-01-01"),
+        horizon_end=pd.Timestamp("2024-01-03"),
+        today=pd.Timestamp("2024-01-01"),
+        lag_days=1,
+    )
+
+    center_series = _timeline_to_series(timeline, "C", "SKU")
+    assert center_series.loc[pd.Timestamp("2024-01-02")] == 5
+
+    in_transit_series = _timeline_to_series(timeline, "In-Transit", "SKU")
+    assert in_transit_series.loc[pd.Timestamp("2024-01-01")] == 5
+    assert in_transit_series.loc[pd.Timestamp("2024-01-02")] == 0

--- a/tests/test_timeline_v5.py
+++ b/tests/test_timeline_v5.py
@@ -1,0 +1,98 @@
+import pandas as pd
+
+from scm_dashboard_v4.timeline import build_timeline as build_timeline_v4
+from scm_dashboard_v5 import BuildInputs, build_timeline_bundle
+
+
+def _make_sample_inputs():
+    snapshot = pd.DataFrame(
+        [
+            {"snapshot_date": "2024-01-01", "center": "A", "resource_code": "S1", "stock_qty": 100},
+            {"snapshot_date": "2024-01-02", "center": "A", "resource_code": "S1", "stock_qty": 90},
+            {"snapshot_date": "2024-01-01", "center": "B", "resource_code": "S1", "stock_qty": 50},
+        ]
+    )
+    moves = pd.DataFrame(
+        [
+            {
+                "resource_code": "S1",
+                "qty_ea": 20,
+                "from_center": "A",
+                "to_center": "B",
+                "onboard_date": "2024-01-04",
+                "carrier_mode": "SEA",
+            },
+            {
+                "resource_code": "S1",
+                "qty_ea": 30,
+                "from_center": "B",
+                "to_center": "A",
+                "onboard_date": "2024-01-03",
+                "arrival_date": "2024-01-05",
+                "carrier_mode": "AIR",
+            },
+            {
+                "resource_code": "S1",
+                "qty_ea": 10,
+                "from_center": "Factory",
+                "to_center": "A",
+                "onboard_date": "2024-01-02",
+                "event_date": "2024-01-04",
+                "carrier_mode": "WIP",
+            },
+        ]
+    )
+    return BuildInputs(snapshot=snapshot, moves=moves)
+
+
+def test_bundle_matches_v4_timeline_output():
+    inputs = _make_sample_inputs()
+    centers = ["A", "B"]
+    skus = ["S1"]
+    start = pd.Timestamp("2024-01-01")
+    end = pd.Timestamp("2024-01-05")
+    today = pd.Timestamp("2024-01-02")
+
+    bundle = build_timeline_bundle(
+        inputs,
+        centers=centers,
+        skus=skus,
+        start=start,
+        end=end,
+        today=today,
+        lag_days=2,
+    )
+    v5_timeline = bundle.concat()
+
+    v4_timeline = build_timeline_v4(
+        inputs.snapshot,
+        inputs.moves,
+        centers_sel=centers,
+        skus_sel=skus,
+        start_dt=start,
+        horizon_end=end,
+        today=today,
+        lag_days=2,
+    )
+
+    pd.testing.assert_frame_equal(
+        v5_timeline.sort_values(["center", "resource_code", "date"]).reset_index(drop=True),
+        v4_timeline.sort_values(["center", "resource_code", "date"]).reset_index(drop=True),
+    )
+
+
+def test_bundle_exposes_component_frames():
+    inputs = _make_sample_inputs()
+    bundle = build_timeline_bundle(
+        inputs,
+        centers=["A", "B"],
+        skus=["S1"],
+        start=pd.Timestamp("2024-01-01"),
+        end=pd.Timestamp("2024-01-05"),
+        today=pd.Timestamp("2024-01-02"),
+        lag_days=2,
+    )
+
+    assert set(bundle.center_lines["center"].unique()) == {"A", "B"}
+    assert set(bundle.in_transit_lines["center"].unique()) == {"In-Transit"}
+    assert set(bundle.wip_lines["center"].unique()) == {"WIP"}

--- a/v5_main.py
+++ b/v5_main.py
@@ -1,0 +1,255 @@
+"""Streamlit entry point for the SCM dashboard v5 pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+from scm_dashboard_v4.loaders import load_from_excel, load_from_gsheet_api
+from scm_dashboard_v4.processing import (
+    load_wip_from_incoming,
+    merge_wip_as_moves,
+    normalize_moves,
+    normalize_refined_snapshot,
+)
+from scm_dashboard_v5.pipeline import BuildInputs, build_timeline_bundle
+
+
+@dataclass
+class LoadedData:
+    moves: pd.DataFrame
+    snapshot: pd.DataFrame
+
+
+def _load_from_excel_uploader() -> Optional[LoadedData]:
+    """Return normalized data loaded from an uploaded Excel file."""
+
+    file = st.file_uploader("엑셀 업로드 (.xlsx)", type=["xlsx"], key="v5_excel")
+    if file is None:
+        return None
+
+    df_move, df_ref, df_incoming, _ = load_from_excel(file)
+    moves = normalize_moves(df_move)
+    snapshot = normalize_refined_snapshot(df_ref)
+
+    try:
+        wip_df = load_wip_from_incoming(df_incoming)
+        moves = merge_wip_as_moves(moves, wip_df)
+        if wip_df is not None and not wip_df.empty:
+            st.success(f"WIP {len(wip_df)}건 반영 완료")
+    except Exception as exc:  # pragma: no cover - streamlit feedback
+        st.warning(f"WIP 불러오기 실패: {exc}")
+
+    return LoadedData(moves=moves, snapshot=snapshot)
+
+
+def _load_from_gsheet_button() -> Optional[LoadedData]:
+    """Return normalized data retrieved from Google Sheets."""
+
+    if not st.button("Google Sheets에서 데이터 로드", type="primary", key="v5_gsheet"):
+        return None
+
+    df_move, df_ref, df_incoming = load_from_gsheet_api()
+    if df_move.empty or df_ref.empty:
+        st.error("Google Sheets에서 데이터를 불러올 수 없습니다. 권한을 확인해주세요.")
+        return None
+
+    moves = normalize_moves(df_move)
+    snapshot = normalize_refined_snapshot(df_ref)
+
+    try:
+        wip_df = load_wip_from_incoming(df_incoming)
+        moves = merge_wip_as_moves(moves, wip_df)
+        if wip_df is not None and not wip_df.empty:
+            st.success(f"WIP {len(wip_df)}건 반영 완료")
+    except Exception as exc:  # pragma: no cover - streamlit feedback
+        st.warning(f"WIP 불러오기 실패: {exc}")
+
+    return LoadedData(moves=moves, snapshot=snapshot)
+
+
+def _ensure_data() -> Optional[LoadedData]:
+    """Load data via the available tabs and persist it in the session state."""
+
+    if "v5_data" in st.session_state:
+        return st.session_state["v5_data"]
+
+    tab_excel, tab_gsheet = st.tabs(["엑셀 업로드", "Google Sheets"])
+
+    with tab_excel:
+        data = _load_from_excel_uploader()
+        if data is not None:
+            st.session_state["_v5_source"] = "excel"
+            st.session_state["v5_data"] = data
+            return data
+
+    with tab_gsheet:
+        data = _load_from_gsheet_button()
+        if data is not None:
+            st.session_state["_v5_source"] = "gsheet"
+            st.session_state["v5_data"] = data
+            return data
+
+    return None
+
+
+def _center_and_sku_options(moves: pd.DataFrame, snapshot: pd.DataFrame) -> Tuple[list[str], list[str]]:
+    """Derive selectable centers and SKUs from moves and snapshot frames."""
+
+    move_centers = set(moves["from_center"].dropna().astype(str)) | set(
+        moves["to_center"].dropna().astype(str)
+    )
+    snap_centers = set(snapshot["center"].dropna().astype(str))
+    centers = sorted({c for c in move_centers | snap_centers if c and c.lower() != "nan"})
+
+    skus = sorted(snapshot["resource_code"].dropna().astype(str).unique().tolist())
+    if not skus:
+        skus = sorted(moves["resource_code"].dropna().astype(str).unique().tolist())
+
+    return centers, skus
+
+
+def _date_bounds(moves: pd.DataFrame, snapshot: pd.DataFrame) -> Tuple[pd.Timestamp, pd.Timestamp]:
+    """Compute a sensible default date window based on available data."""
+
+    dates = [
+        snapshot["date"].min() if not snapshot.empty else None,
+        snapshot["date"].max() if not snapshot.empty else None,
+        moves.get("onboard_date").min() if "onboard_date" in moves.columns else None,
+        moves.get("pred_inbound_date").min() if "pred_inbound_date" in moves.columns else None,
+        moves.get("pred_inbound_date").max() if "pred_inbound_date" in moves.columns else None,
+        moves.get("event_date").max() if "event_date" in moves.columns else None,
+    ]
+    dates = [pd.to_datetime(d).normalize() for d in dates if pd.notna(d)]
+    if not dates:
+        today = pd.Timestamp.today().normalize()
+        return today - pd.Timedelta(days=30), today + pd.Timedelta(days=30)
+
+    return min(dates), max(dates)
+
+
+def _build_timeline(
+    *,
+    data: LoadedData,
+    centers: list[str],
+    skus: list[str],
+    start: pd.Timestamp,
+    end: pd.Timestamp,
+    lag_days: int,
+) -> Optional[pd.DataFrame]:
+    """Run the v5 pipeline and return the concatenated timeline."""
+
+    today = pd.Timestamp.today().normalize()
+    bundle = build_timeline_bundle(
+        BuildInputs(snapshot=data.snapshot, moves=data.moves),
+        centers=centers,
+        skus=skus,
+        start=start,
+        end=end,
+        today=today,
+        lag_days=lag_days,
+    )
+    timeline = bundle.concat()
+    if timeline.empty:
+        return None
+    return timeline
+
+
+def _plot_timeline(timeline: pd.DataFrame) -> None:
+    """Render the timeline using Plotly."""
+
+    fig = px.line(
+        timeline,
+        x="date",
+        y="stock_qty",
+        color="center",
+        line_dash="resource_code",
+        markers=True,
+        title="센터/라인별 재고 추이",
+    )
+    fig.update_layout(hovermode="x unified")
+    st.plotly_chart(fig, use_container_width=True)
+
+
+def main() -> None:
+    """Entrypoint for running the v5 dashboard in Streamlit."""
+
+    st.set_page_config(page_title="SCM Dashboard v5", layout="wide")
+    st.title("SCM Dashboard v5")
+    st.caption("모듈화된 v5 파이프라인을 이용한 Streamlit 엔트리 포인트")
+
+    data = _ensure_data()
+    if data is None:
+        st.info("데이터를 로드하면 차트와 테이블이 표시됩니다.")
+        return
+
+    centers, skus = _center_and_sku_options(data.moves, data.snapshot)
+    if not centers or not skus:
+        st.warning("센터 또는 SKU 정보를 찾을 수 없습니다.")
+        return
+
+    min_dt, max_dt = _date_bounds(data.moves, data.snapshot)
+    today = pd.Timestamp.today().normalize()
+    default_start = max(min_dt, today - pd.Timedelta(days=30))
+    default_end = min(max_dt, today + pd.Timedelta(days=60))
+
+    with st.sidebar:
+        st.header("필터")
+        selected_centers = st.multiselect("센터", centers, default=centers)
+        default_skus = skus if len(skus) <= 10 else skus[:10]
+        selected_skus = st.multiselect("SKU", skus, default=default_skus)
+        date_range = st.date_input(
+            "타임라인 범위",
+            value=(default_start.to_pydatetime(), default_end.to_pydatetime()),
+            min_value=min_dt.to_pydatetime(),
+            max_value=max_dt.to_pydatetime(),
+        )
+        lag_days = st.slider("WIP 지연 일수", min_value=0, max_value=30, value=7, step=1)
+
+    if not selected_centers:
+        st.warning("최소 한 개의 센터를 선택하세요.")
+        return
+    if not selected_skus:
+        st.warning("최소 한 개의 SKU를 선택하세요.")
+        return
+
+    if isinstance(date_range, tuple):
+        start_date, end_date = date_range
+    else:
+        start_date = date_range
+        end_date = date_range
+
+    start_ts = pd.Timestamp(start_date).normalize()
+    end_ts = pd.Timestamp(end_date).normalize()
+    if end_ts < start_ts:
+        st.warning("종료일이 시작일보다 빠릅니다.")
+        return
+
+    timeline = _build_timeline(
+        data=data,
+        centers=selected_centers,
+        skus=selected_skus,
+        start=start_ts,
+        end=end_ts,
+        lag_days=lag_days,
+    )
+
+    if timeline is None:
+        st.info("선택한 조건에 해당하는 타임라인 데이터가 없습니다.")
+        return
+
+    _plot_timeline(timeline)
+
+    st.subheader("센터별 타임라인")
+    st.dataframe(timeline[timeline["center"].isin(selected_centers)])
+
+    st.subheader("In-Transit / WIP")
+    st.dataframe(timeline[~timeline["center"].isin(selected_centers)])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a `v5_main.py` Streamlit script that wires the modular v5 pipeline into an executable dashboard entry point
- support Excel and Google Sheets data loading with WIP merging before calling the new timeline bundle
- expose filters, range controls, and Plotly visualisation so centre, in-transit, and WIP lines can be explored interactively

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de026705f883288eeaf13e99224167