### PR TITLE
Add v4 sidebar controls and consumption forecast hook to v5 dashboard

### DIFF
--- a/scm_dashboard_v5/forecast/consumption.py
+++ b/scm_dashboard_v5/forecast/consumption.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, Optional, Sequence
 
 import pandas as pd
 
@@ -17,14 +17,24 @@ def estimate_daily_consumption(sales: pd.DataFrame, *, window: int = 28) -> pd.D
 
 def apply_consumption_with_events(
     timeline: pd.DataFrame,
-    events: pd.DataFrame,
+    snapshot: pd.DataFrame,
     *,
-    centers: Iterable[str],
-    skus: Iterable[str],
+    centers: Sequence[str],
+    skus: Sequence[str],
+    start: pd.Timestamp,
+    end: pd.Timestamp,
+    lookback_days: int = 28,
+    events: Optional[Iterable[dict]] = None,
 ) -> pd.DataFrame:
+    """Delegate to the v4 helper while normalising parameter names."""
+
     return v4_consumption.apply_consumption_with_events(
         timeline,
-        events,
-        centers=list(centers),
-        skus=list(skus),
+        snapshot,
+        list(centers),
+        list(skus),
+        pd.to_datetime(start).normalize(),
+        pd.to_datetime(end).normalize(),
+        int(lookback_days),
+        list(events) if events else None,
     )


### PR DESCRIPTION
## Summary
- add the v4 "표시 옵션" controls, inbound lag inputs, and promotion expander to the v5 sidebar
- pass promotion events and lookback settings into the v5 consumption forecast so the timeline matches v4 behaviour
- hide 생산중 traces when disabled or 태광KR is not selected while keeping existing chart styling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de19342bcc8328a5cca93e2b73c4a5