### PR TITLE
Add Amazon sales chart to v5 dashboard

### DIFF
--- a/scm_dashboard_v5/analytics/__init__.py
+++ b/scm_dashboard_v5/analytics/__init__.py
@@ -2,10 +2,11 @@
 
 from .inventory import pivot_inventory_cost_from_raw
 from .kpi import kpi_breakdown_per_sku
-from .sales import prepare_amazon_sales_series
+from .sales import prepare_amazon_daily_sales, prepare_amazon_sales_series
 
 __all__ = [
     "pivot_inventory_cost_from_raw",
     "kpi_breakdown_per_sku",
+    "prepare_amazon_daily_sales",
     "prepare_amazon_sales_series",
 ]

--- a/scm_dashboard_v5/analytics/sales.py
+++ b/scm_dashboard_v5/analytics/sales.py
@@ -1,11 +1,88 @@
-"""Sales adapters re-exporting the existing v4 series helpers."""
+"""Sales adapters extending the existing v4 series helpers for v5."""
 
 from __future__ import annotations
+
+from typing import Iterable, Sequence
 
 import pandas as pd
 
 from scm_dashboard_v4 import sales as v4_sales
 
 
-def prepare_amazon_sales_series(sales: pd.DataFrame) -> pd.DataFrame:
-    return v4_sales.prepare_amazon_sales_series(sales)
+def prepare_amazon_sales_series(
+    snapshot: pd.DataFrame,
+    skus: Iterable[str],
+    start_dt: pd.Timestamp,
+    end_dt: pd.Timestamp,
+    *,
+    center: str = "AMZUS",
+    rolling_window: int = 7,
+) -> v4_sales.AmazonSalesResult:
+    """Proxy to the v4 helper for single-centre Amazon series."""
+
+    return v4_sales.prepare_amazon_sales_series(
+        snapshot,
+        skus,
+        start_dt,
+        end_dt,
+        center=center,
+        rolling_window=rolling_window,
+    )
+
+
+def prepare_amazon_daily_sales(
+    snapshot: pd.DataFrame,
+    *,
+    centers: Sequence[str] | None,
+    skus: Iterable[str],
+    start_dt: pd.Timestamp,
+    end_dt: pd.Timestamp,
+    rolling_window: int = 7,
+) -> v4_sales.AmazonSalesResult:
+    """Aggregate Amazon daily sales across the supplied centres.
+
+    When multiple Amazon centres are provided the records are normalised to a
+    synthetic "AMAZON" centre before delegating to the v4 helper so inventory
+    and daily sales are summed per date.
+    """
+
+    if "center" not in snapshot.columns:
+        raise KeyError("snapshot must contain a 'center' column for Amazon prep")
+
+    if centers:
+        centers_list = [str(center) for center in centers if str(center).strip()]
+    else:
+        centers_list = []
+
+    df = snapshot.copy()
+    df["center"] = df["center"].astype(str)
+
+    if centers_list:
+        df = df[df["center"].isin(centers_list)]
+        if df.empty:
+            label = centers_list[0]
+            return v4_sales.AmazonSalesResult(pd.DataFrame(), label)
+        label = centers_list[0] if len(centers_list) == 1 else "AMAZON"
+    else:
+        mask = df["center"].str.contains("amazon", case=False, na=False) | (
+            df["center"].str.upper().str.startswith("AMZ")
+        )
+        df = df[mask]
+        if df.empty:
+            return v4_sales.AmazonSalesResult(pd.DataFrame(), "AMZUS")
+        label = df["center"].iloc[0]
+
+    df = df.copy()
+    df["center"] = label
+
+    return v4_sales.prepare_amazon_sales_series(
+        df,
+        skus,
+        start_dt,
+        end_dt,
+        center=label,
+        rolling_window=rolling_window,
+    )
+
+
+__all__ = ["prepare_amazon_sales_series", "prepare_amazon_daily_sales"]

--- a/v5_main.py
+++ b/v5_main.py
@@ -7,6 +7,7 @@ from typing import Iterable, Optional, Tuple
 
 import pandas as pd
 import plotly.express as px
+import plotly.graph_objects as go
 import streamlit as st
 
 from scm_dashboard_v4.config import CENTER_COL, PALETTE
@@ -18,6 +19,7 @@ from scm_dashboard_v4.processing import (
     normalize_moves,
     normalize_refined_snapshot,
 )
+from scm_dashboard_v5.analytics import prepare_amazon_daily_sales
 from scm_dashboard_v5.forecast import apply_consumption_with_events
 from scm_dashboard_v5.pipeline import BuildInputs, build_timeline_bundle
 
@@ -389,6 +391,68 @@ def main() -> None:
         show_production=show_prod,
         selected_centers=selected_centers,
     )
+
+    # -------------------- Amazon US sales vs. inventory --------------------
+    amazon_candidates = [
+        center
+        for center in selected_centers
+        if str(center).strip()
+        and (
+            "amazon" in str(center).lower()
+            or str(center).upper().startswith("AMZ")
+        )
+    ]
+
+    sales_result = prepare_amazon_daily_sales(
+        data.snapshot,
+        centers=amazon_candidates,
+        skus=selected_skus,
+        start_dt=start_ts,
+        end_dt=end_ts,
+        rolling_window=7,
+    )
+
+    st.subheader("Amazon US 일일 판매 & 재고")
+    sales_df = sales_result.data
+    if sales_df.empty:
+        st.caption("선택된 SKU/기간에 대한 Amazon US 판매 데이터가 없습니다.")
+    else:
+        sales_fig = go.Figure()
+        sales_fig.add_bar(
+            x=sales_df["date"],
+            y=sales_df["sales_qty"],
+            name="일일 판매량",
+            marker_color="#ff7f0e",
+            opacity=0.8,
+        )
+        sales_fig.add_scatter(
+            x=sales_df["date"],
+            y=sales_df["inventory_qty"],
+            name="Amazon 재고",
+            mode="lines",
+            line=dict(color="#1f77b4", width=2),
+            yaxis="y2",
+        )
+        sales_fig.add_scatter(
+            x=sales_df["date"],
+            y=sales_df["sales_roll_mean"],
+            name="판매 7일 이동평균",
+            mode="lines",
+            line=dict(color="#d62728", dash="dash"),
+            visible="legendonly",
+        )
+
+        sales_fig.update_layout(
+            barmode="overlay",
+            hovermode="x unified",
+            legend_title_text="Amazon 판매/재고",
+            xaxis=dict(title="날짜"),
+            yaxis=dict(title="일일 판매량(EA)"),
+            yaxis2=dict(title="Amazon 재고(EA)", overlaying="y", side="right"),
+            margin=dict(l=20, r=40, t=40, b=20),
+        )
+        sales_fig.update_yaxes(tickformat=",.0f")
+        st.plotly_chart(sales_fig, use_container_width=True, config={"displaylogo": False})
 
     window_start = start_ts
     window_end = end_ts


### PR DESCRIPTION
## Summary
- add v5 analytics helpers that wrap the existing Amazon sales preparation logic
- render the Amazon sales vs. inventory chart in the v5 Streamlit dashboard using the new helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de1b3900ec8328a77512ead630e9f1