### PR TITLE
Overlay forecast projections on timeline and Amazon inventory charts

### DIFF
--- a/v5_main.py
+++ b/v5_main.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import Iterable, Optional, Tuple
 
 import pandas as pd
-import plotly.express as px
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 import streamlit as st
@@ -168,8 +167,9 @@ def _build_timeline(
 
 
 def _plot_timeline(
-    timeline: pd.DataFrame,
+    actual_timeline: pd.DataFrame,
     *,
+    forecast_timeline: Optional[pd.DataFrame] = None,
     start: pd.Timestamp,
     end: pd.Timestamp,
     show_production: bool,
@@ -177,75 +177,102 @@ def _plot_timeline(
 ) -> None:
     """Render the timeline using Plotly with styling borrowed from v4."""
 
-    if timeline.empty:
+    if actual_timeline.empty and (forecast_timeline is None or forecast_timeline.empty):
         st.info("선택한 조건에 해당하는 타임라인 데이터가 없습니다.")
         return
 
-    vis_df = timeline.copy()
-    vis_df["date"] = pd.to_datetime(vis_df["date"]).dt.normalize()
-    vis_df = vis_df[(vis_df["date"] >= start) & (vis_df["date"] <= end)]
+    def _prepare(frame: pd.DataFrame) -> pd.DataFrame:
+        if frame is None or frame.empty:
+            return pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+        df = frame.copy()
+        df["date"] = pd.to_datetime(df["date"]).dt.normalize()
+        df = df[(df["date"] >= start) & (df["date"] <= end)]
+        df["center"] = df["center"].replace({"In-Transit": "이동중", "WIP": "생산중"})
+        return df
 
-    center_translation = {"In-Transit": "이동중", "WIP": "생산중"}
-    vis_df["center"] = vis_df["center"].replace(center_translation)
+    actual_df = _prepare(actual_timeline)
+    forecast_df = _prepare(forecast_timeline)
 
     centers_set = {str(c) for c in selected_centers}
     if ("태광KR" not in centers_set) or not show_production:
-        vis_df = vis_df[vis_df["center"] != "생산중"]
+        actual_df = actual_df[actual_df["center"] != "생산중"]
+        forecast_df = forecast_df[forecast_df["center"] != "생산중"]
 
-    vis_df = vis_df[vis_df["stock_qty"] != 0]
-    if vis_df.empty:
+    today = pd.Timestamp.today().normalize()
+    actual_df = actual_df[actual_df["stock_qty"] != 0]
+    actual_df = actual_df[actual_df["date"] <= today]
+
+    if forecast_df is not None and not forecast_df.empty:
+        forecast_df = forecast_df[forecast_df["stock_qty"] != 0]
+        forecast_df = forecast_df[forecast_df["date"] >= today]
+    else:
+        forecast_df = pd.DataFrame(columns=["date", "center", "resource_code", "stock_qty"])
+
+    if actual_df.empty and forecast_df.empty:
         st.info("선택한 조건에 해당하는 타임라인 데이터가 없습니다.")
         return
 
-    vis_df["label"] = vis_df["resource_code"].astype(str) + " @ " + vis_df["center"].astype(str)
+    for df in (actual_df, forecast_df):
+        if not df.empty:
+            df["label"] = df["resource_code"].astype(str) + " @ " + df["center"].astype(str)
 
-    fig = px.line(
-        vis_df,
-        x="date",
-        y="stock_qty",
-        color="label",
-        line_shape="hv",
-        title="선택한 SKU × 센터(및 이동중/생산중) 계단식 재고 흐름",
-        render_mode="svg",
+    actual_labels = (
+        actual_df["label"].dropna().unique().tolist() if "label" in actual_df.columns else []
     )
+    forecast_labels = (
+        forecast_df["label"].dropna().unique().tolist() if "label" in forecast_df.columns else []
+    )
+    labels = sorted(set(actual_labels) | set(forecast_labels))
+    line_colors: dict[str, str] = {}
+    for idx, label in enumerate(labels):
+        line_colors[label] = PALETTE[idx % len(PALETTE)]
+
+    fig = go.Figure()
+
+    hover_template = "날짜: %{x|%Y-%m-%d}<br>재고: %{y:,.0f} EA<br>%{fullData.name}<extra></extra>"
+
+    for label in labels:
+        color = line_colors[label]
+        act = actual_df[actual_df["label"] == label].sort_values("date")
+        if not act.empty:
+            fig.add_trace(
+                go.Scatter(
+                    x=act["date"],
+                    y=act["stock_qty"],
+                    mode="lines",
+                    line=dict(color=color, width=1.8),
+                    name=f"{label} · 실데이터",
+                    legendgroup=label,
+                    line_shape="hv",
+                    hovertemplate=hover_template,
+                )
+            )
+
+        fc = forecast_df[forecast_df["label"] == label].sort_values("date")
+        if not fc.empty:
+            fig.add_trace(
+                go.Scatter(
+                    x=fc["date"],
+                    y=fc["stock_qty"],
+                    mode="lines",
+                    line=dict(color=color, dash="dash", width=1.5),
+                    name=f"{label} · 추세 예측치",
+                    legendgroup=label,
+                    line_shape="hv",
+                    hovertemplate=hover_template,
+                )
+            )
 
     fig.update_layout(
         hovermode="x unified",
         xaxis_title="날짜",
         yaxis_title="재고량(EA)",
-        legend_title_text="SKU @ Center / 생산중(점선)",
+        title="선택한 SKU × 센터(및 이동중/생산중) 계단식 재고 흐름",
+        legend_title_text="SKU @ Center · 실데이터/추세 예측치",
         margin=dict(l=20, r=20, t=60, b=20),
     )
     fig.update_yaxes(tickformat=",.0f")
-    fig.update_traces(
-        hovertemplate="날짜: %{x|%Y-%m-%d}<br>재고: %{y:,.0f} EA<br>%{fullData.name}<extra></extra>"
-    )
 
-    line_colors: dict[str, str] = {}
-    color_idx = 0
-    for trace in fig.data:
-        name = trace.name or ""
-        if " @ " in name and name not in line_colors:
-            line_colors[name] = PALETTE[color_idx % len(PALETTE)]
-            color_idx += 1
-
-    for idx, trace in enumerate(fig.data):
-        name = trace.name or ""
-        if " @ " not in name:
-            continue
-        _, center_name = name.split(" @ ", 1)
-        line_color = line_colors.get(name, PALETTE[0])
-        is_transit = center_name in {"이동중", "생산중"}
-        fig.data[idx].update(
-            line=dict(
-                color=line_color,
-                dash="dash" if is_transit else "solid",
-                width=1.0 if is_transit else 1.5,
-            ),
-            opacity=0.8 if is_transit else 1.0,
-        )
-
-    today = pd.Timestamp.today().normalize()
     if start <= today <= end:
         fig.add_vline(x=today, line_width=1, line_dash="solid", line_color="rgba(255, 0, 0, 0.4)")
         fig.add_annotation(
@@ -261,6 +288,7 @@ def _plot_timeline(
         )
 
     st.plotly_chart(fig, use_container_width=True, config={"displaylogo": False})
+    st.caption("실데이터는 실선으로, 추세 예측치는 점선으로 표시됩니다.")
 
 
 def main() -> None:
@@ -438,7 +466,7 @@ def main() -> None:
 
     st.divider()
 
-    timeline = _build_timeline(
+    timeline_actual = _build_timeline(
         data=data,
         centers=selected_centers,
         skus=selected_skus,
@@ -447,13 +475,14 @@ def main() -> None:
         lag_days=lag_days,
     )
 
-    if timeline is None:
+    if timeline_actual is None:
         st.info("선택한 조건에 해당하는 타임라인 데이터가 없습니다.")
         return
 
+    forecast_timeline: Optional[pd.DataFrame] = None
     if use_cons_forecast:
-        timeline = apply_consumption_with_events(
-            timeline,
+        forecast_timeline = apply_consumption_with_events(
+            timeline_actual,
             snapshot_df,
             centers=selected_centers,
             skus=selected_skus,
@@ -464,7 +493,8 @@ def main() -> None:
         )
 
     _plot_timeline(
-        timeline,
+        timeline_actual,
+        forecast_timeline=forecast_timeline,
         start=start_ts,
         end=end_ts,
         show_production=show_prod,
@@ -512,17 +542,50 @@ def main() -> None:
             ),
             secondary_y=False,
         )
+        forecast_inventory = pd.DataFrame()
+        if (
+            forecast_timeline is not None
+            and not forecast_timeline.empty
+            and amazon_candidates
+        ):
+            forecast_inventory = forecast_timeline.copy()
+            forecast_inventory["date"] = pd.to_datetime(
+                forecast_inventory["date"], errors="coerce"
+            ).dt.normalize()
+            forecast_inventory = forecast_inventory[~forecast_inventory["center"].isin(["In-Transit", "WIP"])]
+            forecast_inventory = forecast_inventory[
+                forecast_inventory["center"].isin({str(c) for c in amazon_candidates})
+            ]
+            if not forecast_inventory.empty:
+                forecast_inventory = (
+                    forecast_inventory.groupby("date", as_index=False)["stock_qty"].sum()
+                )
+                forecast_inventory = forecast_inventory[
+                    forecast_inventory["date"] >= pd.Timestamp.today().normalize()
+                ]
+
         sales_fig.add_trace(
             go.Scatter(
                 x=sales_df["date"],
                 y=sales_df["inventory_qty"],
                 mode="lines+markers",
-                name="Amazon Inventory (EA)",
+                name="Amazon Inventory (EA) · 실데이터",
                 line=dict(color=PALETTE[1], width=2),
                 marker=dict(size=4),
             ),
             secondary_y=True,
         )
+        if not forecast_inventory.empty:
+            sales_fig.add_trace(
+                go.Scatter(
+                    x=forecast_inventory["date"],
+                    y=forecast_inventory["stock_qty"],
+                    mode="lines",
+                    name="Amazon Inventory (EA) · 추세 예측치",
+                    line=dict(color=PALETTE[1], dash="dash", width=1.6),
+                ),
+                secondary_y=True,
+            )
         sales_fig.add_trace(
             go.Scatter(
                 x=sales_df["date"],
@@ -552,6 +615,8 @@ def main() -> None:
             tickformat=",.0f",
         )
         st.plotly_chart(sales_fig, use_container_width=True, config={"displaylogo": False})
+        if not forecast_inventory.empty:
+            st.caption("Amazon 재고 실데이터는 실선, 추세 예측치는 점선으로 표시됩니다.")
 
     window_start = start_ts
     window_end = end_ts


### PR DESCRIPTION
## Summary
- separate actual and projected inventory timelines so future-demand forecasts extend beyond today with clear legend and captioning
- reuse the consumption forecast adapter to generate dashed projection overlays for both the main timeline and Amazon inventory chart

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de24c291248328b3d498991eb28895